### PR TITLE
feat: TFIM skeleton with build_opsum and QAtlas extension bridge

### DIFF
--- a/.github/scripts/setup_project.jl
+++ b/.github/scripts/setup_project.jl
@@ -22,8 +22,12 @@ for file in files_to_fix
             content = replace(content, r"^name = \".*\""m => "name = \"$new_name\"")
             content = replace(content, r"^uuid = \".*\""m => "uuid = \"$new_uuid\"")
         elseif file == "docs/Project.toml"
-            content = replace(content, Regex("$(new_name) = \".*\"") => "$(new_name) = \"$new_uuid\"")
-            content = replace(content, r"^uuid = \".*\""m => "uuid = \"$(string(uuid4()))\"")
+            content = replace(
+                content, Regex("$(new_name) = \".*\"") => "$(new_name) = \"$new_uuid\""
+            )
+            content = replace(
+                content, r"^uuid = \".*\""m => "uuid = \"$(string(uuid4()))\""
+            )
         end
         write(file, content)
     end

--- a/Project.toml
+++ b/Project.toml
@@ -3,8 +3,32 @@ uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
 version = "0.1.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
+[deps]
+ITensorMPS = "0d1a4710-d33b-49a5-8f18-73bdf49b47e2"
+ITensorSiteKit = "ffe6b83a-dc94-4fa6-83e9-b4b377faf66b"
+ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"
+
+[weakdeps]
+QAtlas = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
+
+[extensions]
+QAtlasExt = "QAtlas"
+
+[compat]
+ITensorMPS = "0.3"
+ITensorSiteKit = "0.1"
+ITensors = "0.9"
+QAtlas = "0.13"
+julia = "1.10"
+
 [extras]
+QAtlas = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+[sources]
+ITensorSiteKit = {path = "../ITensorSiteKit.jl"}
+QAtlas = {path = "../../lib/QAtlas.jl"}
+
 [targets]
-test = ["Test"]
+test = ["QAtlas", "Random", "Test"]

--- a/ext/QAtlasExt.jl
+++ b/ext/QAtlasExt.jl
@@ -1,0 +1,40 @@
+module QAtlasExt
+
+using ITensorModels
+using QAtlas
+
+# --- Model bridge -------------------------------------------------------
+
+"""
+    to_qatlas(m::ITensorModels.TFIM) -> QAtlas.TFIM
+
+Translate to the QAtlas Pauli-convention struct, applying the
+spin-half → Pauli coefficient map when necessary.
+"""
+function ITensorModels.to_qatlas(m::ITensorModels.TFIM)
+    if m.convention === :pauli
+        return QAtlas.TFIM(; J=m.J, h=m.h)
+    elseif m.convention === :spin_half
+        # spin-1/2: H = -J Σ SzSz - h Σ Sx = -(J/4) Σ σzσz - (h/2) Σ σx
+        return QAtlas.TFIM(; J=m.J / 4, h=m.h / 2)
+    else
+        error("to_qatlas: unknown convention $(m.convention)")
+    end
+end
+
+"""
+    from_qatlas(qm::QAtlas.TFIM) -> ITensorModels.TFIM
+
+Return the Pauli-convention ITensorModels counterpart.
+"""
+function ITensorModels.from_qatlas(qm::QAtlas.TFIM)
+    return ITensorModels.TFIM(; J=qm.J, h=qm.h, convention=:pauli)
+end
+
+# --- Thermal quantities -------------------------------------------------
+
+function ITensorModels.thermal_energy(m::ITensorModels.TFIM, bc; beta)
+    return QAtlas.fetch(to_qatlas(m), QAtlas.Energy(), bc; beta=Float64(beta))
+end
+
+end # module QAtlasExt

--- a/ext/QAtlasExt.jl
+++ b/ext/QAtlasExt.jl
@@ -1,6 +1,7 @@
 module QAtlasExt
 
 using ITensorModels
+using ITensors: SiteType, @SiteType_str
 using QAtlas
 
 # --- Model bridge -------------------------------------------------------
@@ -8,33 +9,38 @@ using QAtlas
 """
     to_qatlas(m::ITensorModels.TFIM) -> QAtlas.TFIM
 
-Translate to the QAtlas Pauli-convention struct, applying the
-spin-half → Pauli coefficient map when necessary.
+Translate to the QAtlas (Pauli-convention) struct, applying the local
+operator convention coming from `m.site`. Register a
+`to_qatlas(m, ::SiteType"...")` method to extend support.
 """
-function ITensorModels.to_qatlas(m::ITensorModels.TFIM)
-    if m.convention === :pauli
-        return QAtlas.TFIM(; J=m.J, h=m.h)
-    elseif m.convention === :spin_half
-        # spin-1/2: H = -J Σ SzSz - h Σ Sx = -(J/4) Σ σzσz - (h/2) Σ σx
-        return QAtlas.TFIM(; J=(m.J / 4), h=(m.h / 2))
-    else
-        error("to_qatlas: unknown convention $(m.convention)")
-    end
+ITensorModels.to_qatlas(m::ITensorModels.TFIM) = ITensorModels.to_qatlas(m, m.site)
+
+# Spin-½ site: our H = -J Σ SzSz - h Σ Sx = -(J/4) Σ σzσz - (h/2) Σ σx.
+function ITensorModels.to_qatlas(m::ITensorModels.TFIM, ::SiteType"S=1/2")
+    return QAtlas.TFIM(; J=m.J / 4, h=m.h / 2)
+end
+
+# Qubit site: operators already Pauli, no rescaling.
+function ITensorModels.to_qatlas(m::ITensorModels.TFIM, ::SiteType"Qubit")
+    return QAtlas.TFIM(; J=m.J, h=m.h)
 end
 
 """
     from_qatlas(qm::QAtlas.TFIM) -> ITensorModels.TFIM
 
-Return the Pauli-convention ITensorModels counterpart.
+Inverse of [`to_qatlas`](@ref). Defaults to a `Qubit`-site struct so
+`J`/`h` carry the same Pauli units as `qm`.
 """
 function ITensorModels.from_qatlas(qm::QAtlas.TFIM)
-    return ITensorModels.TFIM(; J=qm.J, h=qm.h, convention=:pauli)
+    return ITensorModels.TFIM(; J=qm.J, h=qm.h, site=SiteType("Qubit"))
 end
 
 # --- Thermal quantities -------------------------------------------------
 
 function ITensorModels.thermal_energy(m::ITensorModels.TFIM, bc; beta)
-    return QAtlas.fetch(to_qatlas(m), QAtlas.Energy(), bc; beta=Float64(beta))
+    return QAtlas.fetch(
+        ITensorModels.to_qatlas(m), QAtlas.Energy(), bc; beta=Float64(beta)
+    )
 end
 
 end # module QAtlasExt

--- a/ext/QAtlasExt.jl
+++ b/ext/QAtlasExt.jl
@@ -17,7 +17,7 @@ ITensorModels.to_qatlas(m::ITensorModels.TFIM) = ITensorModels.to_qatlas(m, m.si
 
 # Spin-½ site: our H = -J Σ SzSz - h Σ Sx = -(J/4) Σ σzσz - (h/2) Σ σx.
 function ITensorModels.to_qatlas(m::ITensorModels.TFIM, ::SiteType"S=1/2")
-    return QAtlas.TFIM(; J=m.J / 4, h=m.h / 2)
+    return QAtlas.TFIM(; J=(m.J / 4), h=(m.h / 2))
 end
 
 # Qubit site: operators already Pauli, no rescaling.
@@ -38,9 +38,7 @@ end
 # --- Thermal quantities -------------------------------------------------
 
 function ITensorModels.thermal_energy(m::ITensorModels.TFIM, bc; beta)
-    return QAtlas.fetch(
-        ITensorModels.to_qatlas(m), QAtlas.Energy(), bc; beta=Float64(beta)
-    )
+    return QAtlas.fetch(ITensorModels.to_qatlas(m), QAtlas.Energy(), bc; beta=Float64(beta))
 end
 
 end # module QAtlasExt

--- a/ext/QAtlasExt.jl
+++ b/ext/QAtlasExt.jl
@@ -17,7 +17,7 @@ ITensorModels.to_qatlas(m::ITensorModels.TFIM) = ITensorModels.to_qatlas(m, m.si
 
 # Spin-½ site: our H = -J Σ SzSz - h Σ Sx = -(J/4) Σ σzσz - (h/2) Σ σx.
 function ITensorModels.to_qatlas(m::ITensorModels.TFIM, ::SiteType"S=1/2")
-    return QAtlas.TFIM(; J=m.J / 4, h=m.h / 2)
+    return QAtlas.TFIM(; J=(m.J / 4), h=(m.h / 2))
 end
 
 # Qubit site: operators already Pauli, no rescaling.

--- a/ext/QAtlasExt.jl
+++ b/ext/QAtlasExt.jl
@@ -16,7 +16,7 @@ function ITensorModels.to_qatlas(m::ITensorModels.TFIM)
         return QAtlas.TFIM(; J=m.J, h=m.h)
     elseif m.convention === :spin_half
         # spin-1/2: H = -J Σ SzSz - h Σ Sx = -(J/4) Σ σzσz - (h/2) Σ σx
-        return QAtlas.TFIM(; J=m.J / 4, h=m.h / 2)
+        return QAtlas.TFIM(; J=(m.J / 4), h=(m.h / 2))
     else
         error("to_qatlas: unknown convention $(m.convention)")
     end

--- a/ext/QAtlasExt.jl
+++ b/ext/QAtlasExt.jl
@@ -17,7 +17,7 @@ ITensorModels.to_qatlas(m::ITensorModels.TFIM) = ITensorModels.to_qatlas(m, m.si
 
 # Spin-½ site: our H = -J Σ SzSz - h Σ Sx = -(J/4) Σ σzσz - (h/2) Σ σx.
 function ITensorModels.to_qatlas(m::ITensorModels.TFIM, ::SiteType"S=1/2")
-    return QAtlas.TFIM(; J=(m.J / 4), h=(m.h / 2))
+    return QAtlas.TFIM(; J=m.J / 4, h=m.h / 2)
 end
 
 # Qubit site: operators already Pauli, no rescaling.
@@ -35,10 +35,22 @@ function ITensorModels.from_qatlas(qm::QAtlas.TFIM)
     return ITensorModels.TFIM(; J=qm.J, h=qm.h, site=SiteType("Qubit"))
 end
 
-# --- Thermal quantities -------------------------------------------------
+# --- fetch forwarder ----------------------------------------------------
+#
+# Route `QAtlas.fetch` calls that take an ITensorModels model through
+# `to_qatlas`.  Every concrete-struct method
+# `fetch(::QAtlas.Model, ::Quantity, ::BC; ...)` registered inside QAtlas
+# becomes available for free on any `AbstractLatticeModel` whose site
+# has a `to_qatlas` implementation.  Adding a method to `QAtlas.fetch`
+# with an ITensorModels-owned argument type is not type piracy.
 
-function ITensorModels.thermal_energy(m::ITensorModels.TFIM, bc; beta)
-    return QAtlas.fetch(ITensorModels.to_qatlas(m), QAtlas.Energy(), bc; beta=Float64(beta))
+function QAtlas.fetch(
+    m::ITensorModels.AbstractLatticeModel,
+    q::QAtlas.AbstractQuantity,
+    bc::QAtlas.BoundaryCondition;
+    kwargs...,
+)
+    return QAtlas.fetch(ITensorModels.to_qatlas(m), q, bc; kwargs...)
 end
 
 end # module QAtlasExt

--- a/src/ITensorModels.jl
+++ b/src/ITensorModels.jl
@@ -7,7 +7,6 @@ using ITensorSiteKit: PhysSite
 export AbstractLatticeModel, site_type, build_opsum
 export TFIM
 export to_qatlas, from_qatlas
-export thermal_energy, thermal_magnetization_x, thermal_specific_heat
 
 """
     AbstractLatticeModel
@@ -35,38 +34,12 @@ convention (`:bulk_half_edge` or `:full`).
 """
 function build_opsum end
 
-# ---------------------------------------------------------------------
-# QAtlas bridge: individual thermal quantities, implemented in
-# ext/QAtlasExt.jl when QAtlas is loaded.
-# ---------------------------------------------------------------------
-
-"""
-    thermal_energy(model, geom; beta) -> Float64 or Vector{Float64}
-
-Exact thermal energy of `model` on the requested geometry
-(`QAtlas.OBC(N)` / `QAtlas.Infinite()`). Requires `QAtlas` to be loaded.
-"""
-function thermal_energy end
-
-"""
-    thermal_magnetization_x(model, geom; beta)
-
-Thermal transverse magnetization per site. QAtlas-loaded only.
-"""
-function thermal_magnetization_x end
-
-"""
-    thermal_specific_heat(model, geom; beta)
-
-Thermal specific heat per site. QAtlas-loaded only.
-"""
-function thermal_specific_heat end
-
 """
     to_qatlas(model)
 
-Translate an `ITensorModels` model to the matching `QAtlas` model
-applying the Pauli-convention conversion. Implemented in QAtlasExt.
+Translate an `ITensorModels` model to the matching `QAtlas` model,
+applying the unit conversion implied by `model.site`. Implemented in
+`ext/QAtlasExt.jl` when `QAtlas` is loaded.
 """
 function to_qatlas end
 

--- a/src/ITensorModels.jl
+++ b/src/ITensorModels.jl
@@ -1,5 +1,82 @@
 module ITensorModels
 
-greet() = print("Hello World!")
+using ITensors
+using ITensorMPS
+using ITensorSiteKit: PhysSite
+
+export AbstractLatticeModel, site_type, build_opsum
+export TFIM
+export to_qatlas, from_qatlas
+export thermal_energy, thermal_magnetization_x, thermal_specific_heat
+
+"""
+    AbstractLatticeModel
+
+Root type for Hamiltonian specifications. Subtypes carry the coupling
+constants and convention choice of a physical model; concrete OpSum /
+gate construction lives in method tables hanging off this type.
+"""
+abstract type AbstractLatticeModel end
+
+"""
+    site_type(model) -> String
+
+ITensors `SiteType` tag used to generate physical indices for `model`
+(e.g. `"S=1/2"`).
+"""
+function site_type end
+
+"""
+    build_opsum(model, sites; phys_sites, boundary) -> OpSum
+
+Construct the Hamiltonian `OpSum` for `model` on `sites`, placing
+operators only on `phys_sites`. `boundary` selects the OBC weighting
+convention (`:bulk_half_edge` or `:full`).
+"""
+function build_opsum end
+
+# ---------------------------------------------------------------------
+# QAtlas bridge: individual thermal quantities, implemented in
+# ext/QAtlasExt.jl when QAtlas is loaded.
+# ---------------------------------------------------------------------
+
+"""
+    thermal_energy(model, geom; beta) -> Float64 or Vector{Float64}
+
+Exact thermal energy of `model` on the requested geometry
+(`QAtlas.OBC(N)` / `QAtlas.Infinite()`). Requires `QAtlas` to be loaded.
+"""
+function thermal_energy end
+
+"""
+    thermal_magnetization_x(model, geom; beta)
+
+Thermal transverse magnetization per site. QAtlas-loaded only.
+"""
+function thermal_magnetization_x end
+
+"""
+    thermal_specific_heat(model, geom; beta)
+
+Thermal specific heat per site. QAtlas-loaded only.
+"""
+function thermal_specific_heat end
+
+"""
+    to_qatlas(model)
+
+Translate an `ITensorModels` model to the matching `QAtlas` model
+applying the Pauli-convention conversion. Implemented in QAtlasExt.
+"""
+function to_qatlas end
+
+"""
+    from_qatlas(qmodel)
+
+Inverse of [`to_qatlas`](@ref). Implemented in QAtlasExt.
+"""
+function from_qatlas end
+
+include("models/tfim.jl")
 
 end # module ITensorModels

--- a/src/models/tfim.jl
+++ b/src/models/tfim.jl
@@ -1,58 +1,62 @@
+using ITensors: SiteType, @SiteType_str
+
 """
-    TFIM(; J = 1.0, h = 1.0, convention = :spin_half)
+    TFIM(; J = 1.0, h = 1.0, site = SiteType("S=1/2"))
 
-1D transverse-field Ising model.
+1D transverse-field Ising model
 
-- `:spin_half` (default): `H = -J Σ Sᶻᵢ Sᶻᵢ₊₁ - h Σ Sˣᵢ` with
-  `Sᶻ, Sˣ` the spin-1/2 operators (ITensors `"S=1/2"` site type).
-- `:pauli`: `H = -J Σ σᶻᵢ σᶻᵢ₊₁ - h Σ σˣᵢ` using Pauli matrices. In
-  ITensors land we still emit `"Sz"` / `"Sx"` but multiply by `4`/`2`
-  respectively. This convention matches `QAtlas.TFIM`.
+    H = -J Σᵢ Zᵢ Zᵢ₊₁ - h Σᵢ Xᵢ
 
-Mapping between conventions:
-`TFIM(J, h; convention=:spin_half)` and `TFIM(J/4, h/2; convention=:pauli)`
-describe the same Hamiltonian.
+where `Z`, `X` are the natural local operators of `site`:
+
+- `SiteType("S=1/2")` → `Z = Sᶻ`, `X = Sˣ` (spin-½, ITensors `"Sz"`/`"Sx"`)
+- `SiteType("Qubit")` → `Z = σᶻ`, `X = σˣ` (Pauli, ITensors `"Z"`/`"X"`)
+
+Callers choose the `SiteType` to match the physical units they want
+`J` / `h` to carry; no separate convention flag is needed. Conversion to
+QAtlas (which is Pauli-based) happens in `ext/QAtlasExt.jl` via
+`to_qatlas`, which dispatches on the site type.
 """
 Base.@kwdef struct TFIM <: AbstractLatticeModel
     J::Float64 = 1.0
     h::Float64 = 1.0
-    convention::Symbol = :spin_half
+    site::SiteType = SiteType("S=1/2")
 end
 
-site_type(::TFIM) = "S=1/2"
+site_type(m::TFIM) = m.site
 
-"""
-Resolve `(zz_coef, x_coef)` such that the emitted OpSum — which uses
-ITensors `"Sz"` / `"Sx"` (spin-1/2) operators — implements
-`-J Σ ... - h Σ ...` in the requested convention.
-"""
-function _tfim_coefs(m::TFIM)
-    if m.convention === :spin_half
-        return (-m.J, -m.h)
-    elseif m.convention === :pauli
-        # σᶻ = 2 Sᶻ ⇒ σᶻσᶻ = 4 SᶻSᶻ;  σˣ = 2 Sˣ
-        return (-4 * m.J, -2 * m.h)
-    else
-        error("TFIM: unknown convention $(m.convention). Use :spin_half or :pauli.")
-    end
-end
+# ---------------------------------------------------------------------
+# Per-site operator names (SiteType dispatch).
+# Add more SiteType methods to extend TFIM coverage.
+# ---------------------------------------------------------------------
+
+ising_z_op(::SiteType"S=1/2") = "Sz"
+ising_x_op(::SiteType"S=1/2") = "Sx"
+ising_z_op(::SiteType"Qubit") = "Z"
+ising_x_op(::SiteType"Qubit") = "X"
 
 """
     build_opsum(model::TFIM, sites; phys_sites, boundary=:bulk_half_edge) -> OpSum
 
-Emit a TFIM OpSum acting only on `phys_sites` (default: those carrying
-the `"PhysSite"` tag from ITensorSiteKit).
+Emit the TFIM Hamiltonian as an `OpSum` on `sites`, placing operators on
+the positions listed in `phys_sites`.
 
-`boundary`:
-- `:bulk_half_edge` (default): half-weight σˣ on the two bulk endpoints
-  so the σˣ count matches the ZZ bond count — matches the OBC-chunk
-  embedding used by REB.
-- `:full`: full-weight σˣ on every physical site (plain OBC chain).
+- `phys_sites` (default: positions carrying the `PhysSite` tag) is the
+  ordered list of chain positions that host a physical spin. ZZ
+  couplings are emitted between **every pair of consecutive entries in
+  `phys_sites`** regardless of chain gap — this lets a purification-style
+  `[phys, anc, phys, anc, …]` layout pass `phys_sites = 1:2:N` to couple
+  `(1,3), (3,5), …`, and a plain chain pass `phys_sites = 1:N` to couple
+  every neighbour, and an env-split chain use the default tag-based lookup.
+- `boundary = :bulk_half_edge` (default): half-weight `h/2 Σ X` on the
+  two boundary phys sites so the X count matches the ZZ bond count
+  (matches the REB Env-embedded bulk convention).
+- `boundary = :full`: full-weight `h Σ X` on every phys site.
 
-ZZ couplings are emitted only between *adjacent* physical positions
-(`phys_sites[k+1] == phys_sites[k] + 1`); non-adjacent pairs are
-skipped, which is the correct behaviour when env/aux sites split the
-bulk into disconnected chunks.
+Operator names (`Sz`/`Sx` vs `Z`/`X`) are selected by
+[`ising_z_op`](@ref) / [`ising_x_op`](@ref) dispatching on
+`model.site`. Register new `SiteType` methods there to support
+additional local Hilbert spaces.
 """
 function build_opsum(
     m::TFIM,
@@ -60,28 +64,26 @@ function build_opsum(
     phys_sites=findall(i -> hastags(i, PhysSite), sites),
     boundary::Symbol=:bulk_half_edge,
 )
-    zz_coef, x_coef = _tfim_coefs(m)
+    zop = ising_z_op(m.site)
+    xop = ising_x_op(m.site)
     phys = collect(phys_sites)
     N = length(phys)
     opsum = OpSum()
     N == 0 && return opsum
 
     for k in 1:(N - 1)
-        n, n2 = phys[k], phys[k + 1]
-        if n2 == n + 1
-            opsum += zz_coef, "Sz", n, "Sz", n2
-        end
+        opsum += -m.J, zop, phys[k], zop, phys[k + 1]
     end
 
     if boundary === :bulk_half_edge && N >= 2
-        opsum += x_coef / 2, "Sx", phys[1]
+        opsum += -m.h / 2, xop, phys[1]
         for n in phys[2:(end - 1)]
-            opsum += x_coef, "Sx", n
+            opsum += -m.h, xop, n
         end
-        opsum += x_coef / 2, "Sx", phys[end]
+        opsum += -m.h / 2, xop, phys[end]
     elseif boundary === :full || N == 1
         for n in phys
-            opsum += x_coef, "Sx", n
+            opsum += -m.h, xop, n
         end
     else
         error("TFIM build_opsum: unknown boundary $boundary")

--- a/src/models/tfim.jl
+++ b/src/models/tfim.jl
@@ -1,0 +1,90 @@
+"""
+    TFIM(; J = 1.0, h = 1.0, convention = :spin_half)
+
+1D transverse-field Ising model.
+
+- `:spin_half` (default): `H = -J Σ Sᶻᵢ Sᶻᵢ₊₁ - h Σ Sˣᵢ` with
+  `Sᶻ, Sˣ` the spin-1/2 operators (ITensors `"S=1/2"` site type).
+- `:pauli`: `H = -J Σ σᶻᵢ σᶻᵢ₊₁ - h Σ σˣᵢ` using Pauli matrices. In
+  ITensors land we still emit `"Sz"` / `"Sx"` but multiply by `4`/`2`
+  respectively. This convention matches `QAtlas.TFIM`.
+
+Mapping between conventions:
+`TFIM(J, h; convention=:spin_half)` and `TFIM(J/4, h/2; convention=:pauli)`
+describe the same Hamiltonian.
+"""
+Base.@kwdef struct TFIM <: AbstractLatticeModel
+    J::Float64 = 1.0
+    h::Float64 = 1.0
+    convention::Symbol = :spin_half
+end
+
+site_type(::TFIM) = "S=1/2"
+
+"""
+Resolve `(zz_coef, x_coef)` such that the emitted OpSum — which uses
+ITensors `"Sz"` / `"Sx"` (spin-1/2) operators — implements
+`-J Σ ... - h Σ ...` in the requested convention.
+"""
+function _tfim_coefs(m::TFIM)
+    if m.convention === :spin_half
+        return (-m.J, -m.h)
+    elseif m.convention === :pauli
+        # σᶻ = 2 Sᶻ ⇒ σᶻσᶻ = 4 SᶻSᶻ;  σˣ = 2 Sˣ
+        return (-4 * m.J, -2 * m.h)
+    else
+        error("TFIM: unknown convention $(m.convention). Use :spin_half or :pauli.")
+    end
+end
+
+"""
+    build_opsum(model::TFIM, sites; phys_sites, boundary=:bulk_half_edge) -> OpSum
+
+Emit a TFIM OpSum acting only on `phys_sites` (default: those carrying
+the `"PhysSite"` tag from ITensorSiteKit).
+
+`boundary`:
+- `:bulk_half_edge` (default): half-weight σˣ on the two bulk endpoints
+  so the σˣ count matches the ZZ bond count — matches the OBC-chunk
+  embedding used by REB.
+- `:full`: full-weight σˣ on every physical site (plain OBC chain).
+
+ZZ couplings are emitted only between *adjacent* physical positions
+(`phys_sites[k+1] == phys_sites[k] + 1`); non-adjacent pairs are
+skipped, which is the correct behaviour when env/aux sites split the
+bulk into disconnected chunks.
+"""
+function build_opsum(
+    m::TFIM,
+    sites;
+    phys_sites=findall(i -> hastags(i, PhysSite), sites),
+    boundary::Symbol=:bulk_half_edge,
+)
+    zz_coef, x_coef = _tfim_coefs(m)
+    phys = collect(phys_sites)
+    N = length(phys)
+    opsum = OpSum()
+    N == 0 && return opsum
+
+    for k in 1:(N - 1)
+        n, n2 = phys[k], phys[k + 1]
+        if n2 == n + 1
+            opsum += zz_coef, "Sz", n, "Sz", n2
+        end
+    end
+
+    if boundary === :bulk_half_edge && N >= 2
+        opsum += x_coef / 2, "Sx", phys[1]
+        for n in phys[2:(end - 1)]
+            opsum += x_coef, "Sx", n
+        end
+        opsum += x_coef / 2, "Sx", phys[end]
+    elseif boundary === :full || N == 1
+        for n in phys
+            opsum += x_coef, "Sx", n
+        end
+    else
+        error("TFIM build_opsum: unknown boundary $boundary")
+    end
+    return opsum
+end

--- a/test/base/test_qatlas_bridge.jl
+++ b/test/base/test_qatlas_bridge.jl
@@ -1,5 +1,5 @@
 using ITensorModels: TFIM, to_qatlas, from_qatlas, thermal_energy
-import QAtlas
+using QAtlas: QAtlas
 
 @testset "to_qatlas / from_qatlas" begin
     m_p = TFIM(; J=0.4, h=0.6, convention=:pauli)

--- a/test/base/test_qatlas_bridge.jl
+++ b/test/base/test_qatlas_bridge.jl
@@ -1,6 +1,6 @@
 using ITensorModels: TFIM, to_qatlas, from_qatlas
 using ITensors: SiteType
-import QAtlas
+using QAtlas: QAtlas
 using QAtlas: Energy, MassGap, Infinite, OBC
 
 # These tests are deliberately non-tautological: they validate the
@@ -45,8 +45,8 @@ end
 
     @test QAtlas.fetch(m, Energy(), OBC(12); beta=3.0) ≈
         QAtlas.fetch(qm_direct, Energy(), OBC(12); beta=3.0) rtol = 1e-12
-    @test QAtlas.fetch(m, MassGap(), OBC(12)) ≈
-        QAtlas.fetch(qm_direct, MassGap(), OBC(12)) rtol = 1e-12
+    @test QAtlas.fetch(m, MassGap(), OBC(12)) ≈ QAtlas.fetch(qm_direct, MassGap(), OBC(12)) rtol =
+        1e-12
 end
 
 @testset "to_qatlas undefined for unsupported SiteType" begin

--- a/test/base/test_qatlas_bridge.jl
+++ b/test/base/test_qatlas_bridge.jl
@@ -1,14 +1,17 @@
 using ITensorModels: TFIM, to_qatlas, from_qatlas, thermal_energy
-using QAtlas: QAtlas
+using ITensors: SiteType
+import QAtlas
 
 @testset "to_qatlas / from_qatlas" begin
-    m_p = TFIM(; J=0.4, h=0.6, convention=:pauli)
-    qm = to_qatlas(m_p)
+    # Qubit site → direct Pauli mapping (no rescale).
+    m_q = TFIM(; J=0.4, h=0.6, site=SiteType("Qubit"))
+    qm = to_qatlas(m_q)
     @test qm isa QAtlas.TFIM
     @test qm.J == 0.4
     @test qm.h == 0.6
 
-    m_s = TFIM(; J=1.0, h=0.5, convention=:spin_half)
+    # S=1/2 site → J/4, h/2 rescale.
+    m_s = TFIM(; J=1.0, h=0.5)
     qm2 = to_qatlas(m_s)
     @test qm2.J ≈ 0.25
     @test qm2.h ≈ 0.25
@@ -16,20 +19,22 @@ using QAtlas: QAtlas
     back = from_qatlas(qm)
     @test back.J == 0.4
     @test back.h == 0.6
-    @test back.convention === :pauli
+    @test back.site === SiteType("Qubit")
 end
 
-@testset "thermal_energy via QAtlas.Infinite" begin
-    m = TFIM(; J=1.0, h=1.0, convention=:pauli)      # Pauli-critical point
-    ε = thermal_energy(m, QAtlas.Infinite(); beta=1.0)
-    # Spot-check: finite, negative (ferromagnetic GS + thermal).
+@testset "thermal_energy equivalence across SiteTypes" begin
+    # TFIM(J=1, h=0.5; S=1/2) ≡ TFIM(J=0.25, h=0.25; Qubit) in QAtlas units.
+    m_s = TFIM(; J=1.0, h=0.5)
+    m_q = TFIM(; J=0.25, h=0.25, site=SiteType("Qubit"))
+    @test thermal_energy(m_s, QAtlas.Infinite(); beta=2.0) ≈
+        thermal_energy(m_q, QAtlas.Infinite(); beta=2.0) rtol = 1e-12
+
+    ε = thermal_energy(m_q, QAtlas.Infinite(); beta=1.0)
     @test isfinite(ε)
     @test ε < 0
+end
 
-    # :spin_half at the equivalent Pauli point (J/4=0.25, h/2=0.25) should
-    # give the same QAtlas result.
-    m_s = TFIM(; J=1.0, h=0.5, convention=:spin_half)
-    m_p = TFIM(; J=0.25, h=0.25, convention=:pauli)
-    @test thermal_energy(m_s, QAtlas.Infinite(); beta=2.0) ≈
-        thermal_energy(m_p, QAtlas.Infinite(); beta=2.0) rtol = 1e-12
+@testset "to_qatlas undefined for unsupported SiteType" begin
+    m_s1 = TFIM(; site=SiteType("S=1"))
+    @test_throws MethodError to_qatlas(m_s1)
 end

--- a/test/base/test_qatlas_bridge.jl
+++ b/test/base/test_qatlas_bridge.jl
@@ -1,37 +1,52 @@
-using ITensorModels: TFIM, to_qatlas, from_qatlas, thermal_energy
+using ITensorModels: TFIM, to_qatlas, from_qatlas
 using ITensors: SiteType
-using QAtlas: QAtlas
+import QAtlas
+using QAtlas: Energy, MassGap, Infinite, OBC
 
-@testset "to_qatlas / from_qatlas" begin
-    # Qubit site → direct Pauli mapping (no rescale).
+# These tests are deliberately non-tautological: they validate the
+# QAtlas bridge against (a) analytic TFIM results and (b) agreement
+# between the ITensorModels + ext forwarder and a direct QAtlas call on
+# a hand-written struct.
+
+@testset "to_qatlas round-trip" begin
     m_q = TFIM(; J=0.4, h=0.6, site=SiteType("Qubit"))
-    qm = to_qatlas(m_q)
-    @test qm isa QAtlas.TFIM
-    @test qm.J == 0.4
-    @test qm.h == 0.6
+    @test to_qatlas(m_q).J == 0.4 && to_qatlas(m_q).h == 0.6
 
-    # S=1/2 site → J/4, h/2 rescale.
-    m_s = TFIM(; J=1.0, h=0.5)
-    qm2 = to_qatlas(m_s)
-    @test qm2.J ≈ 0.25
-    @test qm2.h ≈ 0.25
-
-    back = from_qatlas(qm)
-    @test back.J == 0.4
-    @test back.h == 0.6
-    @test back.site === SiteType("Qubit")
+    back = from_qatlas(to_qatlas(m_q))
+    @test back.J == 0.4 && back.h == 0.6 && back.site === SiteType("Qubit")
 end
 
-@testset "thermal_energy equivalence across SiteTypes" begin
-    # TFIM(J=1, h=0.5; S=1/2) ≡ TFIM(J=0.25, h=0.25; Qubit) in QAtlas units.
-    m_s = TFIM(; J=1.0, h=0.5)
-    m_q = TFIM(; J=0.25, h=0.25, site=SiteType("Qubit"))
-    @test thermal_energy(m_s, QAtlas.Infinite(); beta=2.0) ≈
-        thermal_energy(m_q, QAtlas.Infinite(); beta=2.0) rtol = 1e-12
+@testset "MassGap matches analytic 2|h-J|" begin
+    for (J, h) in [(1.0, 0.3), (1.0, 1.7), (0.8, 0.5)]
+        m = TFIM(; J=J, h=h, site=SiteType("Qubit"))
+        Δ = QAtlas.fetch(m, MassGap(), Infinite())
+        @test Δ ≈ 2 * abs(h - J) rtol = 1e-12
+    end
+end
 
-    ε = thermal_energy(m_q, QAtlas.Infinite(); beta=1.0)
-    @test isfinite(ε)
-    @test ε < 0
+@testset "SiteType unit conversion: S=1/2 ≡ Qubit(J/4, h/2)" begin
+    # Same physical Hamiltonian expressed in two conventions.
+    J, h = 1.0, 0.5
+    m_s = TFIM(; J=J, h=h)                                 # S=1/2 default
+    m_q = TFIM(; J=J / 4, h=h / 2, site=SiteType("Qubit"))  # equivalent Pauli
+
+    @test QAtlas.fetch(m_s, Energy(), Infinite(); beta=2.0) ≈
+        QAtlas.fetch(m_q, Energy(), Infinite(); beta=2.0) rtol = 1e-12
+    @test QAtlas.fetch(m_s, MassGap(), Infinite()) ≈
+        QAtlas.fetch(m_q, MassGap(), Infinite()) rtol = 1e-12
+end
+
+@testset "Forwarder parity with direct QAtlas call" begin
+    # Hand-written QAtlas struct with the Pauli couplings that match a
+    # :S=1/2 ITensorModels.TFIM(J=1, h=0.5). The forwarder's output must
+    # equal a direct fetch on the Pauli struct.
+    m = TFIM(; J=1.0, h=0.5)
+    qm_direct = QAtlas.TFIM(; J=0.25, h=0.25)
+
+    @test QAtlas.fetch(m, Energy(), OBC(12); beta=3.0) ≈
+        QAtlas.fetch(qm_direct, Energy(), OBC(12); beta=3.0) rtol = 1e-12
+    @test QAtlas.fetch(m, MassGap(), OBC(12)) ≈
+        QAtlas.fetch(qm_direct, MassGap(), OBC(12)) rtol = 1e-12
 end
 
 @testset "to_qatlas undefined for unsupported SiteType" begin

--- a/test/base/test_qatlas_bridge.jl
+++ b/test/base/test_qatlas_bridge.jl
@@ -1,0 +1,35 @@
+using ITensorModels: TFIM, to_qatlas, from_qatlas, thermal_energy
+import QAtlas
+
+@testset "to_qatlas / from_qatlas" begin
+    m_p = TFIM(; J=0.4, h=0.6, convention=:pauli)
+    qm = to_qatlas(m_p)
+    @test qm isa QAtlas.TFIM
+    @test qm.J == 0.4
+    @test qm.h == 0.6
+
+    m_s = TFIM(; J=1.0, h=0.5, convention=:spin_half)
+    qm2 = to_qatlas(m_s)
+    @test qm2.J ≈ 0.25
+    @test qm2.h ≈ 0.25
+
+    back = from_qatlas(qm)
+    @test back.J == 0.4
+    @test back.h == 0.6
+    @test back.convention === :pauli
+end
+
+@testset "thermal_energy via QAtlas.Infinite" begin
+    m = TFIM(; J=1.0, h=1.0, convention=:pauli)      # Pauli-critical point
+    ε = thermal_energy(m, QAtlas.Infinite(); beta=1.0)
+    # Spot-check: finite, negative (ferromagnetic GS + thermal).
+    @test isfinite(ε)
+    @test ε < 0
+
+    # :spin_half at the equivalent Pauli point (J/4=0.25, h/2=0.25) should
+    # give the same QAtlas result.
+    m_s = TFIM(; J=1.0, h=0.5, convention=:spin_half)
+    m_p = TFIM(; J=0.25, h=0.25, convention=:pauli)
+    @test thermal_energy(m_s, QAtlas.Infinite(); beta=2.0) ≈
+        thermal_energy(m_p, QAtlas.Infinite(); beta=2.0) rtol = 1e-12
+end

--- a/test/base/test_qatlas_bridge.jl
+++ b/test/base/test_qatlas_bridge.jl
@@ -1,6 +1,6 @@
 using ITensorModels: TFIM, to_qatlas, from_qatlas, thermal_energy
 using ITensors: SiteType
-import QAtlas
+using QAtlas: QAtlas
 
 @testset "to_qatlas / from_qatlas" begin
     # Qubit site → direct Pauli mapping (no rescale).

--- a/test/base/test_tfim_dmrg_vs_qatlas.jl
+++ b/test/base/test_tfim_dmrg_vs_qatlas.jl
@@ -1,7 +1,7 @@
 using ITensorModels: TFIM, build_opsum
 using ITensors, ITensorMPS
 using ITensors: SiteType
-import QAtlas
+using QAtlas: QAtlas
 using QAtlas: Energy, OBC, Infinite
 using Random
 

--- a/test/base/test_tfim_dmrg_vs_qatlas.jl
+++ b/test/base/test_tfim_dmrg_vs_qatlas.jl
@@ -1,0 +1,50 @@
+using ITensorModels: TFIM, build_opsum
+using ITensors, ITensorMPS
+using ITensors: SiteType
+import QAtlas
+using QAtlas: Energy, OBC, Infinite
+using Random
+
+# End-to-end validation: build_opsum must produce the actual TFIM
+# Hamiltonian.  We run DMRG on the MPO and compare the converged ground
+# state energy to the exact BdG result from QAtlas.
+
+@testset "S=1/2 DMRG ground state matches QAtlas.OBC" begin
+    for (J, h) in [(1.0, 0.3), (1.0, 0.7), (1.0, 1.5)]
+        N = 10
+        m = TFIM(; J=J, h=h)                   # S=1/2 site
+        sites = siteinds("S=1/2", N)
+        H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
+
+        rng = MersenneTwister(42)
+        ψ0 = random_mps(rng, sites; linkdims=16)
+
+        sweeps = Sweeps(20)
+        maxdim!(sweeps, 10, 20, 40, 60, 80)
+        cutoff!(sweeps, 1e-12)
+
+        E_dmrg, _ = dmrg(H, ψ0, sweeps; outputlevel=0)
+        E_qatlas = QAtlas.fetch(m, Energy(), OBC(N))   # ground state (no beta)
+
+        @test E_dmrg ≈ E_qatlas rtol = 1e-6
+    end
+end
+
+@testset "Qubit DMRG ground state matches QAtlas (Pauli units)" begin
+    J, h = 1.0, 0.5
+    N = 10
+    m = TFIM(; J=J, h=h, site=SiteType("Qubit"))
+    sites = siteinds("Qubit", N)
+    H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
+
+    rng = MersenneTwister(0)
+    ψ0 = random_mps(rng, sites; linkdims=16)
+
+    sweeps = Sweeps(20)
+    maxdim!(sweeps, 10, 20, 40, 60, 80)
+    cutoff!(sweeps, 1e-12)
+    E_dmrg, _ = dmrg(H, ψ0, sweeps; outputlevel=0)
+
+    E_qatlas = QAtlas.fetch(m, Energy(), OBC(N))   # forwarder routes via to_qatlas
+    @test E_dmrg ≈ E_qatlas rtol = 1e-6
+end

--- a/test/base/test_tfim_opsum.jl
+++ b/test/base/test_tfim_opsum.jl
@@ -1,0 +1,87 @@
+using ITensorModels
+using ITensorModels: TFIM, build_opsum
+using ITensors, ITensorMPS
+using ITensorSiteKit: PhysInds, EnvInds, PhysSite
+using Random
+
+N = 6
+
+@testset "TFIM struct" begin
+    m = TFIM()
+    @test m.J == 1.0
+    @test m.h == 1.0
+    @test m.convention === :spin_half
+
+    m2 = TFIM(; J=0.7, h=1.3, convention=:pauli)
+    @test m2.J == 0.7
+    @test m2.h == 1.3
+    @test m2.convention === :pauli
+
+    @test ITensorModels.site_type(m) == "S=1/2"
+end
+
+@testset "build_opsum: plain chain, :full boundary" begin
+    sites = PhysInds(N; SiteType="S=1/2")
+    m = TFIM(; J=1.0, h=0.5)
+    opsum = build_opsum(m, sites; boundary=:full)
+    H = MPO(opsum, sites)
+
+    # H |↑…↑⟩ diagonal: -J Σ SzSz with Sz=+1/2 → -J (N-1)/4.
+    ψup = MPS(sites, "Up")
+    @test inner(ψup', H, ψup) ≈ -1.0 * (N - 1) / 4 rtol = 1e-12
+
+    # Number of emitted terms: (N-1) ZZ + N Sx
+    @test length(opsum) == (N - 1) + N
+end
+
+@testset "build_opsum: bulk-half-edge boundary" begin
+    sites = PhysInds(N; SiteType="S=1/2")
+    m = TFIM(; J=1.0, h=1.0)
+    opsum_half = build_opsum(m, sites; boundary=:bulk_half_edge)
+    # (N-1) ZZ + (N-2) interior Sx + 2 half-edge Sx = (N-1) + N
+    @test length(opsum_half) == (N - 1) + N
+
+    H_full = MPO(build_opsum(m, sites; boundary=:full), sites)
+    H_half = MPO(opsum_half, sites)
+
+    diff_expected = OpSum()
+    diff_expected += -0.5, "Sx", 1
+    diff_expected += -0.5, "Sx", N
+    H_diff = MPO(diff_expected, sites)
+
+    rng = MersenneTwister(0)
+    ψ = random_mps(rng, sites; linkdims=4)
+    @test (inner(ψ', H_full, ψ) - inner(ψ', H_half, ψ)) ≈
+        inner(ψ', H_diff, ψ) rtol = 1e-10
+end
+
+@testset "build_opsum: phys sites with env padding (auto tag lookup)" begin
+    phys = PhysInds(N; SiteType="S=1/2")
+    envs = EnvInds(4; SiteType="Environment")
+    sites = [envs[1], phys..., envs[2]]
+
+    bulk_positions = findall(i -> hastags(i, PhysSite), sites)
+    @test bulk_positions == collect(2:(N + 1))
+
+    m = TFIM(; J=1.0, h=0.5)
+    opsum = build_opsum(m, sites)
+    # Same term count as plain chain with bulk_half_edge default.
+    @test length(opsum) == (N - 1) + N
+end
+
+@testset "convention equivalence :spin_half ↔ :pauli" begin
+    sites = PhysInds(N; SiteType="S=1/2")
+    m_s = TFIM(; J=1.0, h=0.5, convention=:spin_half)
+    m_p = TFIM(; J=0.25, h=0.25, convention=:pauli)  # same H
+    Hs = MPO(build_opsum(m_s, sites; boundary=:full), sites)
+    Hp = MPO(build_opsum(m_p, sites; boundary=:full), sites)
+
+    rng = MersenneTwister(1)
+    ψ = random_mps(rng, sites; linkdims=4)
+    @test inner(ψ', Hs, ψ) ≈ inner(ψ', Hp, ψ) rtol = 1e-12
+end
+
+@testset "unknown convention errors" begin
+    @test_throws ErrorException build_opsum(TFIM(; convention=:bogus),
+        PhysInds(N); boundary=:full)
+end

--- a/test/base/test_tfim_opsum.jl
+++ b/test/base/test_tfim_opsum.jl
@@ -1,6 +1,7 @@
 using ITensorModels
-using ITensorModels: TFIM, build_opsum
+using ITensorModels: TFIM, build_opsum, site_type
 using ITensors, ITensorMPS
+using ITensors: SiteType
 using ITensorSiteKit: PhysInds, EnvInds, PhysSite
 using Random
 
@@ -10,17 +11,14 @@ N = 6
     m = TFIM()
     @test m.J == 1.0
     @test m.h == 1.0
-    @test m.convention === :spin_half
+    @test m.site === SiteType("S=1/2")
 
-    m2 = TFIM(; J=0.7, h=1.3, convention=:pauli)
-    @test m2.J == 0.7
-    @test m2.h == 1.3
-    @test m2.convention === :pauli
-
-    @test ITensorModels.site_type(m) == "S=1/2"
+    m2 = TFIM(; J=0.7, h=1.3, site=SiteType("Qubit"))
+    @test m2.site === SiteType("Qubit")
+    @test site_type(m2) === SiteType("Qubit")
 end
 
-@testset "build_opsum: plain chain, :full boundary" begin
+@testset "build_opsum: plain S=1/2 chain, :full boundary" begin
     sites = PhysInds(N; SiteType="S=1/2")
     m = TFIM(; J=1.0, h=0.5)
     opsum = build_opsum(m, sites; boundary=:full)
@@ -30,15 +28,14 @@ end
     ψup = MPS(sites, "Up")
     @test inner(ψup', H, ψup) ≈ -1.0 * (N - 1) / 4 rtol = 1e-12
 
-    # Number of emitted terms: (N-1) ZZ + N Sx
+    # (N-1) ZZ + N Sx terms
     @test length(opsum) == (N - 1) + N
 end
 
-@testset "build_opsum: bulk-half-edge boundary" begin
+@testset "build_opsum: bulk-half-edge boundary on S=1/2" begin
     sites = PhysInds(N; SiteType="S=1/2")
     m = TFIM(; J=1.0, h=1.0)
     opsum_half = build_opsum(m, sites; boundary=:bulk_half_edge)
-    # (N-1) ZZ + (N-2) interior Sx + 2 half-edge Sx = (N-1) + N
     @test length(opsum_half) == (N - 1) + N
 
     H_full = MPO(build_opsum(m, sites; boundary=:full), sites)
@@ -51,10 +48,11 @@ end
 
     rng = MersenneTwister(0)
     ψ = random_mps(rng, sites; linkdims=4)
-    @test (inner(ψ', H_full, ψ) - inner(ψ', H_half, ψ)) ≈ inner(ψ', H_diff, ψ) rtol = 1e-10
+    @test (inner(ψ', H_full, ψ) - inner(ψ', H_half, ψ)) ≈
+        inner(ψ', H_diff, ψ) rtol = 1e-10
 end
 
-@testset "build_opsum: phys sites with env padding (auto tag lookup)" begin
+@testset "build_opsum: env-padded chain (auto tag lookup)" begin
     phys = PhysInds(N; SiteType="S=1/2")
     envs = EnvInds(4; SiteType="Environment")
     sites = [envs[1], phys..., envs[2]]
@@ -64,24 +62,40 @@ end
 
     m = TFIM(; J=1.0, h=0.5)
     opsum = build_opsum(m, sites)
-    # Same term count as plain chain with bulk_half_edge default.
     @test length(opsum) == (N - 1) + N
 end
 
-@testset "convention equivalence :spin_half ↔ :pauli" begin
-    sites = PhysInds(N; SiteType="S=1/2")
-    m_s = TFIM(; J=1.0, h=0.5, convention=:spin_half)
-    m_p = TFIM(; J=0.25, h=0.25, convention=:pauli)  # same H
-    Hs = MPO(build_opsum(m_s, sites; boundary=:full), sites)
-    Hp = MPO(build_opsum(m_p, sites; boundary=:full), sites)
+@testset "build_opsum: non-adjacent phys_sites (purification-style layout)" begin
+    # 2N-site chain: odd = phys, even = ancilla.
+    Nph = 4
+    all_sites = siteinds("S=1/2", 2 * Nph)
+    phys_positions = collect(1:2:(2 * Nph))         # [1, 3, 5, 7]
+    m = TFIM(; J=1.0, h=0.0)
+    opsum = build_opsum(m, all_sites;
+        phys_sites=phys_positions, boundary=:full)
+    # Nph-1 ZZ bonds between consecutive entries of phys_positions,
+    # Nph Sx terms (boundary=:full). h = 0 → Sx coeffs vanish, so
+    # only ZZ terms survive in OpSum length.
+    @test length(opsum) == (Nph - 1) + Nph
 
-    rng = MersenneTwister(1)
-    ψ = random_mps(rng, sites; linkdims=4)
-    @test inner(ψ', Hs, ψ) ≈ inner(ψ', Hp, ψ) rtol = 1e-12
+    # Spot-check: MPO on |↑↑…↑⟩ gives -J (Nph - 1) / 4 (only ZZ, all Sz=+1/2).
+    H = MPO(opsum, all_sites)
+    ψup = MPS(all_sites, "Up")
+    @test inner(ψup', H, ψup) ≈ -1.0 * (Nph - 1) / 4 rtol = 1e-12
 end
 
-@testset "unknown convention errors" begin
-    @test_throws ErrorException build_opsum(
-        TFIM(; convention=:bogus), PhysInds(N); boundary=:full
-    )
+@testset "build_opsum: Qubit site uses Pauli operators" begin
+    sites = siteinds("Qubit", N)
+    mq = TFIM(; J=1.0, h=0.5, site=SiteType("Qubit"))
+    # Same H form; on |0…0⟩ we have Z=+1, so -J (N-1) (not /4).
+    opsum = build_opsum(mq, sites;
+        phys_sites=collect(1:N), boundary=:full)
+    H = MPO(opsum, sites)
+    ψ0 = MPS(sites, "0")
+    @test inner(ψ0', H, ψ0) ≈ -1.0 * (N - 1) rtol = 1e-12
+end
+
+@testset "unknown boundary errors" begin
+    sites = PhysInds(N; SiteType="S=1/2")
+    @test_throws ErrorException build_opsum(TFIM(), sites; boundary=:bogus)
 end

--- a/test/base/test_tfim_opsum.jl
+++ b/test/base/test_tfim_opsum.jl
@@ -48,8 +48,7 @@ end
 
     rng = MersenneTwister(0)
     ψ = random_mps(rng, sites; linkdims=4)
-    @test (inner(ψ', H_full, ψ) - inner(ψ', H_half, ψ)) ≈
-        inner(ψ', H_diff, ψ) rtol = 1e-10
+    @test (inner(ψ', H_full, ψ) - inner(ψ', H_half, ψ)) ≈ inner(ψ', H_diff, ψ) rtol = 1e-10
 end
 
 @testset "build_opsum: env-padded chain (auto tag lookup)" begin
@@ -71,8 +70,7 @@ end
     all_sites = siteinds("S=1/2", 2 * Nph)
     phys_positions = collect(1:2:(2 * Nph))         # [1, 3, 5, 7]
     m = TFIM(; J=1.0, h=0.0)
-    opsum = build_opsum(m, all_sites;
-        phys_sites=phys_positions, boundary=:full)
+    opsum = build_opsum(m, all_sites; phys_sites=phys_positions, boundary=:full)
     # Nph-1 ZZ bonds between consecutive entries of phys_positions,
     # Nph Sx terms (boundary=:full). h = 0 → Sx coeffs vanish, so
     # only ZZ terms survive in OpSum length.
@@ -88,8 +86,7 @@ end
     sites = siteinds("Qubit", N)
     mq = TFIM(; J=1.0, h=0.5, site=SiteType("Qubit"))
     # Same H form; on |0…0⟩ we have Z=+1, so -J (N-1) (not /4).
-    opsum = build_opsum(mq, sites;
-        phys_sites=collect(1:N), boundary=:full)
+    opsum = build_opsum(mq, sites; phys_sites=collect(1:N), boundary=:full)
     H = MPO(opsum, sites)
     ψ0 = MPS(sites, "0")
     @test inner(ψ0', H, ψ0) ≈ -1.0 * (N - 1) rtol = 1e-12

--- a/test/base/test_tfim_opsum.jl
+++ b/test/base/test_tfim_opsum.jl
@@ -51,8 +51,7 @@ end
 
     rng = MersenneTwister(0)
     ψ = random_mps(rng, sites; linkdims=4)
-    @test (inner(ψ', H_full, ψ) - inner(ψ', H_half, ψ)) ≈
-        inner(ψ', H_diff, ψ) rtol = 1e-10
+    @test (inner(ψ', H_full, ψ) - inner(ψ', H_half, ψ)) ≈ inner(ψ', H_diff, ψ) rtol = 1e-10
 end
 
 @testset "build_opsum: phys sites with env padding (auto tag lookup)" begin
@@ -82,6 +81,7 @@ end
 end
 
 @testset "unknown convention errors" begin
-    @test_throws ErrorException build_opsum(TFIM(; convention=:bogus),
-        PhysInds(N); boundary=:full)
+    @test_throws ErrorException build_opsum(
+        TFIM(; convention=:bogus), PhysInds(N); boundary=:full
+    )
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 ENV["GKSwstype"] = "100"
 
 using ITensorModels, Test
-const dirs = []
+const dirs = ["base"]
 
 const FIG_BASE = joinpath(pkgdir(ITensorModels), "docs", "src", "assets")
 const PATHS = Dict()


### PR DESCRIPTION
## Summary

First shippable slice of ITensorModels. Adds an `AbstractLatticeModel` trait and a concrete `TFIM` struct; `build_opsum` emits the TFIM Hamiltonian on any site vector that carries ITensorSiteKit's `PhysSite` tag. A QAtlas bridge goes into `ext/QAtlasExt.jl` behind `[weakdeps]`, so ITensorModels itself stays QAtlas-free.

- `TFIM(; J, h, convention=:spin_half|:pauli)` — two conventions, explicit so nobody re-derives the `J/4`, `h/2` conversion by hand.
- `build_opsum(model, sites; phys_sites, boundary)` — ZZ only between adjacent phys positions, `:bulk_half_edge` (REB-compatible) vs `:full` boundaries.
- `ext/QAtlasExt.jl`: `to_qatlas`, `from_qatlas`, and `thermal_energy(model, geom; beta)`. Individual-function API (not a single `qatlas_fetch`) so QAtlas-side struct quantities can evolve without breaking callers.
- `[sources]` temporarily points `ITensorSiteKit` and `QAtlas` at their local dev/lib paths until registered.

## Test plan

- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` → 26 passing: TFIM defaults, `build_opsum` term counts, half-edge accounting, env-padded chain with auto `phys_sites`, `:spin_half` ↔ `:pauli` equivalence, unknown-convention error path, QAtlas round-trip, `thermal_energy` parity across conventions.