### PR TITLE
fix(ci): switch [sources] to git URLs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,8 +27,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
-ITensorSiteKit = {path = "../ITensorSiteKit.jl"}
-QAtlas = {path = "../../lib/QAtlas.jl"}
+ITensorSiteKit = {url = "https://github.com/sotashimozono/ITensorSiteKit.jl", rev = "v0.1.0"}
 
 [targets]
 test = ["QAtlas", "Random", "Test"]


### PR DESCRIPTION
Runner fails to resolve local path sources. ITensorSiteKit now pinned to v0.1.0 git URL; QAtlas removed from [sources] (resolved from General).