### PR TITLE
chore: bump 0.1.0 -> 0.2.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]


### PR DESCRIPTION
Minor bump covering #4 (local-term API + TFIML / XXZ1D / Heisenberg1D).