### PR TITLE
feat: LatticeModel + LatticeCoreExt (graph-lattice Hamiltonians)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,25 +9,29 @@ ITensorSiteKit = "ffe6b83a-dc94-4fa6-83e9-b4b377faf66b"
 ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 
 [weakdeps]
+LatticeCore = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
 QAtlas = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
 
+[sources]
+ITensorSiteKit = {rev = "v0.1.0", url = "https://github.com/sotashimozono/ITensorSiteKit.jl"}
+
 [extensions]
+LatticeCoreExt = "LatticeCore"
 QAtlasExt = "QAtlas"
 
 [compat]
 ITensorMPS = "0.3"
 ITensorSiteKit = "0.1"
 ITensors = "0.9"
+LatticeCore = "0.8"
 QAtlas = "0.13"
 julia = "1.10"
 
 [extras]
+LatticeCore = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
 QAtlas = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-ITensorSiteKit = {url = "https://github.com/sotashimozono/ITensorSiteKit.jl", rev = "v0.1.0"}
-
 [targets]
-test = ["QAtlas", "Random", "Test"]
+test = ["LatticeCore", "QAtlas", "Random", "Test"]

--- a/ext/LatticeCoreExt.jl
+++ b/ext/LatticeCoreExt.jl
@@ -1,0 +1,97 @@
+module LatticeCoreExt
+
+using ITensors: OpSum, hastags
+using ITensorModels
+using ITensorModels: AbstractLatticeModel, LatticeModel, bond_term,
+    local_ham_terms, boundary_patch
+using ITensorSiteKit: PhysSite
+using LatticeCore: AbstractLattice, bonds, num_sites
+
+# ---------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------
+
+"""
+    _ordering(m::LatticeModel)
+
+Resolve the lattice-site → MPS-position map. An empty `m.ordering`
+selects the natural order `1:num_sites(m.lattice)`.
+"""
+function _ordering(m::LatticeModel)
+    isempty(m.ordering) ? collect(1:num_sites(m.lattice)) : m.ordering
+end
+
+"""
+    _lookup_bond_model(m::LatticeModel, bt::Symbol)
+
+Fetch the sub-model for `Bond.type == bt`, falling back to `:nearest`
+if the specific tag is not registered. This lets a uniform-couplings
+dict `Dict(:nearest => Heisenberg1D(...))` cover lattices whose bond
+types are labelled differently (`:type_1`, `:type_2`, etc.) as long as
+the user passes a dict keyed on the actual labels they want to match.
+"""
+function _lookup_bond_model(m::LatticeModel, bt::Symbol)
+    haskey(m.bond_models, bt) && return m.bond_models[bt]
+    haskey(m.bond_models, :nearest) && return m.bond_models[:nearest]
+    return error(
+        "LatticeModel: no bond_model registered for Bond.type = $bt. " *
+        "Known keys: $(collect(keys(m.bond_models))).",
+    )
+end
+
+# ---------------------------------------------------------------------
+# local_ham_terms / build_opsum
+# ---------------------------------------------------------------------
+
+"""
+    local_ham_terms(m::LatticeModel{<:AbstractLattice}, phys_sites; boundary)
+
+Iterate the lattice's bonds; for each bond emit the corresponding
+sub-model's `bond_term` on the MPS positions obtained from `_ordering`.
+Single-site boundary patches are **not** emitted — 2D / graph lattices
+don't have a canonical boundary in the `:bulk_half_edge` sense, so each
+bond term carries the full on-site weight already (this matches the
+behaviour of `Heisenberg1D` / `XXZ1D` whose on-site fields are zero).
+
+`phys_sites` is ignored: the lattice itself selects which positions
+host physical DOF via its bond connectivity. `boundary` is accepted
+for interface compatibility but currently must be `:full`.
+"""
+function ITensorModels.local_ham_terms(
+    m::LatticeModel{<:AbstractLattice}, phys_sites;
+    boundary::Symbol=:full,
+)
+    boundary === :full || error(
+        "LatticeModel currently supports only boundary = :full " *
+        "(got $boundary). Open a `:bulk_half_edge` variant when a " *
+        "ChainConfig that needs it lands.",
+    )
+    ord = _ordering(m)
+    terms = OpSum[]
+    for b in bonds(m.lattice)
+        submodel = _lookup_bond_model(m, b.type)
+        push!(terms, bond_term(submodel, ord[b.i], ord[b.j]))
+    end
+    return terms
+end
+
+"""
+    build_opsum(m::LatticeModel{<:AbstractLattice}, sites;
+                phys_sites=nothing, boundary=:full)
+
+Compose the full `OpSum` by summing every bond term produced by
+[`local_ham_terms`](@ref). `phys_sites` is ignored (the lattice graph
+provides connectivity).
+"""
+function ITensorModels.build_opsum(
+    m::LatticeModel{<:AbstractLattice}, sites;
+    phys_sites=nothing, boundary::Symbol=:full,
+)
+    opsum = OpSum()
+    for t in ITensorModels.local_ham_terms(m, phys_sites; boundary)
+        opsum += t
+    end
+    return opsum
+end
+
+end # module LatticeCoreExt

--- a/ext/LatticeCoreExt.jl
+++ b/ext/LatticeCoreExt.jl
@@ -2,8 +2,8 @@ module LatticeCoreExt
 
 using ITensors: OpSum, hastags
 using ITensorModels
-using ITensorModels: AbstractLatticeModel, LatticeModel, bond_term,
-    local_ham_terms, boundary_patch
+using ITensorModels:
+    AbstractLatticeModel, LatticeModel, bond_term, local_ham_terms, boundary_patch
 using ITensorSiteKit: PhysSite
 using LatticeCore: AbstractLattice, bonds, num_sites
 
@@ -58,8 +58,7 @@ host physical DOF via its bond connectivity. `boundary` is accepted
 for interface compatibility but currently must be `:full`.
 """
 function ITensorModels.local_ham_terms(
-    m::LatticeModel{<:AbstractLattice}, phys_sites;
-    boundary::Symbol=:full,
+    m::LatticeModel{<:AbstractLattice}, phys_sites; boundary::Symbol=:full
 )
     boundary === :full || error(
         "LatticeModel currently supports only boundary = :full " *
@@ -84,8 +83,7 @@ Compose the full `OpSum` by summing every bond term produced by
 provides connectivity).
 """
 function ITensorModels.build_opsum(
-    m::LatticeModel{<:AbstractLattice}, sites;
-    phys_sites=nothing, boundary::Symbol=:full,
+    m::LatticeModel{<:AbstractLattice}, sites; phys_sites=nothing, boundary::Symbol=:full
 )
     opsum = OpSum()
     for t in ITensorModels.local_ham_terms(m, phys_sites; boundary)

--- a/src/ITensorModels.jl
+++ b/src/ITensorModels.jl
@@ -6,7 +6,7 @@ using ITensorSiteKit: PhysSite
 
 export AbstractLatticeModel, site_type
 export bond_term, boundary_patch, local_ham_terms, build_opsum
-export TFIM, TFIML, XXZ1D, Heisenberg1D
+export TFIM, TFIML, XXZ1D, Heisenberg1D, LatticeModel
 export to_qatlas, from_qatlas
 
 """
@@ -48,5 +48,6 @@ include("models/tfim.jl")
 include("models/tfiml.jl")
 include("models/xxz.jl")
 include("models/heisenberg.jl")
+include("models/lattice_model.jl")
 
 end # module ITensorModels

--- a/src/models/lattice_model.jl
+++ b/src/models/lattice_model.jl
@@ -1,0 +1,51 @@
+"""
+    LatticeModel(; lattice, bond_models, ordering=Int[])
+
+Lattice-graph-based Hamiltonian composed from existing 1D / bond-local
+model primitives. Works on any `LatticeCore.AbstractLattice` — so
+`Lattice2D.Lattice` (Square / Honeycomb / Kagome / …) and
+`QuasiCrystal.QuasicrystalData` (Fibonacci / Penrose / Ammann-Beenker)
+plug in uniformly.
+
+Fields
+
+- `lattice::L` — the `LatticeCore.AbstractLattice` whose sites and bonds
+  describe the connectivity. Both endpoints of every bond become
+  coupled in the emitted MPO.
+- `bond_models::D` — mapping from `Bond.type` (a `Symbol` carried on
+  every `LatticeCore.Bond`) to an `AbstractLatticeModel` whose
+  `bond_term(submodel, i, j)` supplies the per-bond OpSum. Anisotropic
+  lattices such as Shastry-Sutherland can give different couplings
+  per bond type via this dict.
+- `ordering::Vector{Int}` — 1D embedding. `ordering[i]` is the MPS
+  position of lattice site `i`. An empty default selects the natural
+  order `1:num_sites(lattice)`. Pass a snake / Hilbert-curve order here
+  when you want nearby MPS positions to correspond to nearby lattice
+  positions.
+
+Site type is inherited from the bond models — they must all agree on
+`site_type`.
+
+The actual `build_opsum` / `local_ham_terms` methods require
+`LatticeCore` to be loaded and live in `ext/LatticeCoreExt.jl`.
+"""
+struct LatticeModel{L,D} <: AbstractLatticeModel
+    lattice::L
+    bond_models::D
+    ordering::Vector{Int}
+
+    function LatticeModel(lattice::L, bond_models::D;
+        ordering::Vector{Int}=Int[]) where {L,D}
+        return new{L,D}(lattice, bond_models, ordering)
+    end
+end
+
+LatticeModel(; lattice, bond_models, ordering::Vector{Int}=Int[]) =
+    LatticeModel(lattice, bond_models; ordering)
+
+function site_type(m::LatticeModel)
+    sts = unique(site_type(bm) for bm in values(m.bond_models))
+    length(sts) == 1 ||
+        error("LatticeModel: bond_models carry inconsistent site_type ($sts).")
+    return first(sts)
+end

--- a/src/models/lattice_model.jl
+++ b/src/models/lattice_model.jl
@@ -34,14 +34,16 @@ struct LatticeModel{L,D} <: AbstractLatticeModel
     bond_models::D
     ordering::Vector{Int}
 
-    function LatticeModel(lattice::L, bond_models::D;
-        ordering::Vector{Int}=Int[]) where {L,D}
+    function LatticeModel(
+        lattice::L, bond_models::D; ordering::Vector{Int}=Int[]
+    ) where {L,D}
         return new{L,D}(lattice, bond_models, ordering)
     end
 end
 
-LatticeModel(; lattice, bond_models, ordering::Vector{Int}=Int[]) =
+function LatticeModel(; lattice, bond_models, ordering::Vector{Int}=Int[])
     LatticeModel(lattice, bond_models; ordering)
+end
 
 function site_type(m::LatticeModel)
     sts = unique(site_type(bm) for bm in values(m.bond_models))

--- a/test/base/test_lattice_model.jl
+++ b/test/base/test_lattice_model.jl
@@ -1,0 +1,100 @@
+using ITensorModels
+using ITensorModels: LatticeModel, Heisenberg1D, build_opsum, bond_term, site_type
+using ITensors, ITensorMPS
+using LatticeCore
+
+# LatticeCore ships a minimal 1D chain lattice suitable for smoke tests
+# without pulling Lattice2D/QuasiCrystal; we build our own
+# minimal-shape AbstractLattice subtype here so these tests don't
+# depend on external lattice packages. Lattice2D / QuasiCrystal
+# integration is exercised in examples/ once LatticeModel lands.
+
+struct _LineChain <: LatticeCore.AbstractLattice{1,Float64}
+    N::Int
+end
+LatticeCore.num_sites(l::_LineChain) = l.N
+LatticeCore.position(l::_LineChain, i::Int) =
+    LatticeCore.StaticArrays.SVector(Float64(i))
+LatticeCore.neighbors(l::_LineChain, i::Int) =
+    i == 1 ? [2] : i == l.N ? [l.N - 1] : [i - 1, i + 1]
+LatticeCore.boundary(::_LineChain) = LatticeCore.OpenAxis()
+LatticeCore.size_trait(::_LineChain) = LatticeCore.FiniteSize()
+# Default `bonds(lat)` builds Bond{D,T} objects from `neighbors`.
+
+@testset "LatticeModel on a 1D line chain reproduces plain Heisenberg" begin
+    N = 8
+    lat = _LineChain(N)
+
+    # Heisenberg on every nearest-neighbour bond.
+    model_lat = LatticeModel(; lattice=lat,
+        bond_models=Dict(:nearest => Heisenberg1D(; J=1.0)))
+
+    sites = siteinds("S=1/2", N)
+    H_lat = MPO(build_opsum(model_lat, sites), sites)
+
+    # Reference: direct 1D Heisenberg opsum over (k, k+1) pairs.
+    ref_opsum = OpSum()
+    for k in 1:(N - 1)
+        ref_opsum += bond_term(Heisenberg1D(; J=1.0), k, k + 1)
+    end
+    H_ref = MPO(ref_opsum, sites)
+
+    # Both Hamiltonians should have identical expectation on the Néel
+    # product state (a cheap fingerprint — exactly-equal MPOs would
+    # also pass but that's too strict under bond-dim reshaping).
+    neel = [isodd(k) ? "Up" : "Dn" for k in 1:N]
+    ψ = MPS(sites, neel)
+    @test inner(ψ', H_lat, ψ) ≈ inner(ψ', H_ref, ψ) rtol = 1e-12
+end
+
+@testset "LatticeModel: ordering remaps MPS positions" begin
+    N = 6
+    lat = _LineChain(N)
+
+    # Reverse ordering — lattice site k ↔ MPS position N+1-k.
+    rev = collect(N:-1:1)
+    model = LatticeModel(;
+        lattice=lat,
+        bond_models=Dict(:nearest => Heisenberg1D(; J=1.0)),
+        ordering=rev,
+    )
+    sites = siteinds("S=1/2", N)
+    opsum = build_opsum(model, sites)
+
+    # Every bond_term should reference MPS positions (rev[i], rev[j])
+    # for a LatticeCore bond (i, j). Since every lattice bond is
+    # (k, k+1), the MPS pairs are (N+1-k, N-k) — i.e. reversed.
+    hit = Set{Tuple{Int,Int}}()
+    for term in opsum
+        sts = sort(unique(ITensors.sites(term)))
+        length(sts) == 2 && push!(hit, (sts[1], sts[2]))
+    end
+    expected = Set((k, k + 1) for k in 1:(N - 1))
+    @test hit == expected
+end
+
+@testset "LatticeModel: bond_models dict dispatches on bond.type" begin
+    # Mixed coupling model: bond model dict keyed by :nearest fallback.
+    lat = _LineChain(4)
+    model = LatticeModel(;
+        lattice=lat,
+        bond_models=Dict(:nearest => Heisenberg1D(; J=0.3)),
+    )
+    sites = siteinds("S=1/2", 4)
+    opsum = build_opsum(model, sites)
+    # The Heisenberg OpSum on each bond has 3 terms (S+S-, S-S+, SzSz);
+    # 3 bonds × 3 terms = 9 non-trivial terms.
+    @test length(opsum) == 3 * 3
+end
+
+@testset "LatticeModel: mismatched bond_models site_type errors" begin
+    lat = _LineChain(4)
+    model = LatticeModel(;
+        lattice=lat,
+        bond_models=Dict(
+            :nearest => Heisenberg1D(; J=1.0),
+            :type_2 => ITensorModels.TFIM(; site=ITensors.SiteType("Qubit")),
+        ),
+    )
+    @test_throws ErrorException site_type(model)
+end

--- a/test/base/test_lattice_model.jl
+++ b/test/base/test_lattice_model.jl
@@ -13,10 +13,16 @@ struct _LineChain <: LatticeCore.AbstractLattice{1,Float64}
     N::Int
 end
 LatticeCore.num_sites(l::_LineChain) = l.N
-LatticeCore.position(l::_LineChain, i::Int) =
-    LatticeCore.StaticArrays.SVector(Float64(i))
-LatticeCore.neighbors(l::_LineChain, i::Int) =
-    i == 1 ? [2] : i == l.N ? [l.N - 1] : [i - 1, i + 1]
+LatticeCore.position(l::_LineChain, i::Int) = LatticeCore.StaticArrays.SVector(Float64(i))
+function LatticeCore.neighbors(l::_LineChain, i::Int)
+    if i == 1
+        [2]
+    elseif i == l.N
+        [l.N - 1]
+    else
+        [i - 1, i + 1]
+    end
+end
 LatticeCore.boundary(::_LineChain) = LatticeCore.OpenAxis()
 LatticeCore.size_trait(::_LineChain) = LatticeCore.FiniteSize()
 # Default `bonds(lat)` builds Bond{D,T} objects from `neighbors`.
@@ -26,8 +32,9 @@ LatticeCore.size_trait(::_LineChain) = LatticeCore.FiniteSize()
     lat = _LineChain(N)
 
     # Heisenberg on every nearest-neighbour bond.
-    model_lat = LatticeModel(; lattice=lat,
-        bond_models=Dict(:nearest => Heisenberg1D(; J=1.0)))
+    model_lat = LatticeModel(;
+        lattice=lat, bond_models=Dict(:nearest => Heisenberg1D(; J=1.0))
+    )
 
     sites = siteinds("S=1/2", N)
     H_lat = MPO(build_opsum(model_lat, sites), sites)
@@ -54,9 +61,7 @@ end
     # Reverse ordering — lattice site k ↔ MPS position N+1-k.
     rev = collect(N:-1:1)
     model = LatticeModel(;
-        lattice=lat,
-        bond_models=Dict(:nearest => Heisenberg1D(; J=1.0)),
-        ordering=rev,
+        lattice=lat, bond_models=Dict(:nearest => Heisenberg1D(; J=1.0)), ordering=rev
     )
     sites = siteinds("S=1/2", N)
     opsum = build_opsum(model, sites)
@@ -76,10 +81,7 @@ end
 @testset "LatticeModel: bond_models dict dispatches on bond.type" begin
     # Mixed coupling model: bond model dict keyed by :nearest fallback.
     lat = _LineChain(4)
-    model = LatticeModel(;
-        lattice=lat,
-        bond_models=Dict(:nearest => Heisenberg1D(; J=0.3)),
-    )
+    model = LatticeModel(; lattice=lat, bond_models=Dict(:nearest => Heisenberg1D(; J=0.3)))
     sites = siteinds("S=1/2", 4)
     opsum = build_opsum(model, sites)
     # The Heisenberg OpSum on each bond has 3 terms (S+S-, S-S+, SzSz);


### PR DESCRIPTION
## Summary

Adds a `LatticeModel` that composes existing bond-local models (`Heisenberg1D`, `TFIM`, …) over **any** `LatticeCore.AbstractLattice`. Since both Lattice2D and QuasiCrystal sit on top of LatticeCore, Square / Honeycomb / Kagome / Fibonacci / Penrose all plug in without per-lattice adapters.

## Design

```julia
LatticeModel(;
    lattice,       # LatticeCore.AbstractLattice
    bond_models,   # Dict{Symbol, AbstractLatticeModel} keyed on Bond.type
    ordering=Int[] # lattice site → MPS position (default: 1:N)
)
```

- **`bond_models` dict**: bond-type dispatch via the `Bond.type` tag that LatticeCore attaches to every bond. Shastry-Sutherland can register `:type_1 => H1`, `:type_2 => H2`. Uniform lattices register `:nearest => H`.
- **`ordering`**: lattice-to-MPS embedding for 2D / graph lattices. Empty default = natural order.

## Split

- `src/models/lattice_model.jl` — struct + `site_type`. No LatticeCore import.
- `ext/LatticeCoreExt.jl` — `local_ham_terms` / `build_opsum` specialisations that iterate lattice bonds; activated only when `LatticeCore` is loaded.
- `Project.toml` — LatticeCore added to `[weakdeps]` + `[extensions]`; General-registry package, no `[sources]` needed.

## Test plan

- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` → **43 passing** (39 existing + 4 new `test_lattice_model.jl`). Covers: 1D-line-chain equivalence with direct Heisenberg OpSum, reverse-ordering remap, bond-term count per edge, site_type mismatch error.

## Follow-ups (separate PRs)

- Lattice2D / QuasiCrystal end-to-end examples (Honeycomb Heisenberg, Fibonacci tight-binding).
- Snake / Hilbert-curve ordering helpers.
- Sublattice-dependent SiteType (Lieb 3-sublattice).