### PR TITLE
chore: bump 0.2.0 -> 0.3.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]


### PR DESCRIPTION
Minor bump after #6 (LatticeModel + LatticeCoreExt). New public export, new weakdep; no breaking changes.