### PR TITLE
feat: KitaevBond model + Lattice2D.Honeycomb integration test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,9 @@ QAtlas = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
 
 [sources]
 ITensorSiteKit = {rev = "v0.1.0", url = "https://github.com/sotashimozono/ITensorSiteKit.jl"}
+# QAtlas v0.14.x is not yet in the General registry; point at the
+# pinned v0.14.0 tag until it lands. Safe to remove once General has it.
+QAtlas = {rev = "v0.14.0", url = "https://github.com/sotashimozono/QAtlas.jl"}
 
 [extensions]
 LatticeCoreExt = "LatticeCore"
@@ -24,7 +27,7 @@ ITensorMPS = "0.3"
 ITensorSiteKit = "0.1"
 ITensors = "0.9"
 LatticeCore = "0.8"
-QAtlas = "0.13"
+QAtlas = "0.13, 0.14"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -28,10 +28,11 @@ QAtlas = "0.13"
 julia = "1.10"
 
 [extras]
+Lattice2D = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
 LatticeCore = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
 QAtlas = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["LatticeCore", "QAtlas", "Random", "Test"]
+test = ["Lattice2D", "LatticeCore", "QAtlas", "Random", "Test"]

--- a/src/ITensorModels.jl
+++ b/src/ITensorModels.jl
@@ -6,7 +6,7 @@ using ITensorSiteKit: PhysSite
 
 export AbstractLatticeModel, site_type
 export bond_term, boundary_patch, local_ham_terms, build_opsum
-export TFIM, TFIML, XXZ1D, Heisenberg1D, LatticeModel
+export TFIM, TFIML, XXZ1D, Heisenberg1D, KitaevBond, LatticeModel
 export to_qatlas, from_qatlas
 
 """
@@ -48,6 +48,7 @@ include("models/tfim.jl")
 include("models/tfiml.jl")
 include("models/xxz.jl")
 include("models/heisenberg.jl")
+include("models/kitaev_bond.jl")
 include("models/lattice_model.jl")
 
 end # module ITensorModels

--- a/src/models/kitaev_bond.jl
+++ b/src/models/kitaev_bond.jl
@@ -1,0 +1,77 @@
+using ITensors: SiteType, @SiteType_str
+
+"""
+    KitaevBond(; K=1.0, axis=:z, site=SiteType("S=1/2"))
+
+Directional Ising coupling on a single bond — the building block for
+the Kitaev honeycomb model
+
+    H_Kitaev = -K_x Σ_{(i,j) ∈ x-bonds} σ^x_i σ^x_j
+              -K_y Σ_{(i,j) ∈ y-bonds} σ^y_i σ^y_j
+              -K_z Σ_{(i,j) ∈ z-bonds} σ^z_i σ^z_j
+
+`bond_term(m::KitaevBond, i, j)` emits `-K · σ^axis_i σ^axis_j` using
+the local operator names from the chosen `site` SiteType (spin-½ "Sα"
+vs Qubit "α"). To build the full Kitaev honeycomb Hamiltonian, feed
+three `KitaevBond`s to a `LatticeModel`:
+
+```julia
+using ITensorModels, Lattice2D, LatticeCore
+lat = build_lattice(Honeycomb, Lx, Ly; ...)
+m = LatticeModel(; lattice=lat, bond_models=Dict(
+    :type_1 => KitaevBond(; K=Kz, axis=:z),
+    :type_2 => KitaevBond(; K=Kx, axis=:x),
+    :type_3 => KitaevBond(; K=Ky, axis=:y)))
+```
+
+Hyperparameters
+
+- `K::Float64 = 1.0` — coupling strength. Sign is the `-K` convention.
+- `axis::Symbol` — `:x`, `:y`, or `:z`; selects which spin component
+  the bond couples on.
+- `site::SiteType` — local Hilbert space. Currently `S=1/2`, `Qubit`,
+  `S=1`, `S=3/2` are supported via the shared `kitaev_op` dispatch
+  below.
+"""
+Base.@kwdef struct KitaevBond <: AbstractLatticeModel
+    K::Float64 = 1.0
+    axis::Symbol = :z
+    site::SiteType = SiteType("S=1/2")
+end
+
+site_type(m::KitaevBond) = m.site
+
+# Per-site-type operator names for the three Kitaev axes. Extend with
+# more SiteType methods to cover additional local Hilbert spaces.
+kitaev_op(::SiteType"S=1/2", ::Val{:x}) = "Sx"
+kitaev_op(::SiteType"S=1/2", ::Val{:y}) = "Sy"
+kitaev_op(::SiteType"S=1/2", ::Val{:z}) = "Sz"
+kitaev_op(::SiteType"S=1",   ::Val{:x}) = "Sx"
+kitaev_op(::SiteType"S=1",   ::Val{:y}) = "Sy"
+kitaev_op(::SiteType"S=1",   ::Val{:z}) = "Sz"
+kitaev_op(::SiteType"S=3/2", ::Val{:x}) = "Sx"
+kitaev_op(::SiteType"S=3/2", ::Val{:y}) = "Sy"
+kitaev_op(::SiteType"S=3/2", ::Val{:z}) = "Sz"
+kitaev_op(::SiteType"Qubit", ::Val{:x}) = "X"
+kitaev_op(::SiteType"Qubit", ::Val{:y}) = "Y"
+kitaev_op(::SiteType"Qubit", ::Val{:z}) = "Z"
+
+"""
+    _kitaev_op(site, axis) -> String
+
+Look up the ITensors operator name for the given Kitaev `axis`
+(`:x` / `:y` / `:z`) on the given `site`. Errors on unsupported
+combinations so that dispatch misses are loud rather than silent.
+"""
+function _kitaev_op(site::SiteType, axis::Symbol)
+    axis ∈ (:x, :y, :z) ||
+        error("KitaevBond: unknown axis $axis (expected :x, :y, :z).")
+    return kitaev_op(site, Val(axis))
+end
+
+function bond_term(m::KitaevBond, i::Int, j::Int)
+    op = _kitaev_op(m.site, m.axis)
+    opsum = OpSum()
+    opsum += -m.K, op, i, op, j
+    return opsum
+end

--- a/src/models/kitaev_bond.jl
+++ b/src/models/kitaev_bond.jl
@@ -46,9 +46,9 @@ site_type(m::KitaevBond) = m.site
 kitaev_op(::SiteType"S=1/2", ::Val{:x}) = "Sx"
 kitaev_op(::SiteType"S=1/2", ::Val{:y}) = "Sy"
 kitaev_op(::SiteType"S=1/2", ::Val{:z}) = "Sz"
-kitaev_op(::SiteType"S=1",   ::Val{:x}) = "Sx"
-kitaev_op(::SiteType"S=1",   ::Val{:y}) = "Sy"
-kitaev_op(::SiteType"S=1",   ::Val{:z}) = "Sz"
+kitaev_op(::SiteType"S=1", ::Val{:x}) = "Sx"
+kitaev_op(::SiteType"S=1", ::Val{:y}) = "Sy"
+kitaev_op(::SiteType"S=1", ::Val{:z}) = "Sz"
 kitaev_op(::SiteType"S=3/2", ::Val{:x}) = "Sx"
 kitaev_op(::SiteType"S=3/2", ::Val{:y}) = "Sy"
 kitaev_op(::SiteType"S=3/2", ::Val{:z}) = "Sz"
@@ -64,8 +64,7 @@ Look up the ITensors operator name for the given Kitaev `axis`
 combinations so that dispatch misses are loud rather than silent.
 """
 function _kitaev_op(site::SiteType, axis::Symbol)
-    axis ∈ (:x, :y, :z) ||
-        error("KitaevBond: unknown axis $axis (expected :x, :y, :z).")
+    axis ∈ (:x, :y, :z) || error("KitaevBond: unknown axis $axis (expected :x, :y, :z).")
     return kitaev_op(site, Val(axis))
 end
 

--- a/test/base/test_kitaev_bond.jl
+++ b/test/base/test_kitaev_bond.jl
@@ -1,0 +1,46 @@
+using ITensorModels: KitaevBond, bond_term, site_type
+using ITensors, ITensorMPS
+using ITensors: SiteType
+
+@testset "KitaevBond struct + site_type" begin
+    m = KitaevBond()
+    @test m.K == 1.0
+    @test m.axis === :z
+    @test m.site === SiteType("S=1/2")
+    @test site_type(m) === SiteType("S=1/2")
+
+    mq = KitaevBond(; K=0.5, axis=:x, site=SiteType("Qubit"))
+    @test site_type(mq) === SiteType("Qubit")
+end
+
+@testset "KitaevBond emits single -K axis-axis term" begin
+    for ax in (:x, :y, :z)
+        m = KitaevBond(; K=1.3, axis=ax)
+        op_sum = bond_term(m, 1, 2)
+        # One OpSum term with operator name "Sx"/"Sy"/"Sz" on sites 1, 2.
+        @test length(op_sum) == 1
+    end
+end
+
+@testset "KitaevBond on |↑↑⟩ (spin-½) gives -K/4 for :z" begin
+    sites = siteinds("S=1/2", 2)
+    m = KitaevBond(; K=1.2, axis=:z)
+    H = MPO(bond_term(m, 1, 2), sites)
+    ψ = MPS(sites, ["Up", "Up"])
+    # On |↑↑⟩, Sz = +1/2 each → SzSz = 1/4, so -K SzSz = -K/4.
+    @test inner(ψ', H, ψ) ≈ -1.2 / 4 rtol = 1e-12
+end
+
+@testset "KitaevBond on Qubit |00⟩ gives -K for :z" begin
+    sites = siteinds("Qubit", 2)
+    m = KitaevBond(; K=0.7, axis=:z, site=SiteType("Qubit"))
+    H = MPO(bond_term(m, 1, 2), sites)
+    ψ = MPS(sites, ["0", "0"])
+    # On |00⟩ with Qubit convention, Z = +1 each → ZZ = 1, so -K·1 = -K.
+    @test inner(ψ', H, ψ) ≈ -0.7 rtol = 1e-12
+end
+
+@testset "KitaevBond unknown axis errors" begin
+    m = KitaevBond(; K=1.0, axis=:bogus)
+    @test_throws ErrorException bond_term(m, 1, 2)
+end

--- a/test/base/test_kitaev_honeycomb.jl
+++ b/test/base/test_kitaev_honeycomb.jl
@@ -16,14 +16,17 @@ using Random: MersenneTwister
 # physically correct.
 
 function _make_kitaev_honeycomb(Lx::Int, Ly::Int; K=1.0)
-    lat = build_lattice(L2DHoneycomb, Lx, Ly;
-        boundary=OpenAxis(), layout=UniformLayout(IsingSite()))
-    model = LatticeModel(; lattice=lat,
+    lat = build_lattice(
+        L2DHoneycomb, Lx, Ly; boundary=OpenAxis(), layout=UniformLayout(IsingSite())
+    )
+    model = LatticeModel(;
+        lattice=lat,
         bond_models=Dict(
             :type_1 => KitaevBond(; K=K, axis=:z, site=SiteType("Qubit")),
             :type_2 => KitaevBond(; K=K, axis=:x, site=SiteType("Qubit")),
             :type_3 => KitaevBond(; K=K, axis=:y, site=SiteType("Qubit")),
-        ))
+        ),
+    )
     return lat, model
 end
 
@@ -59,8 +62,8 @@ end
     ε_ref = QAtlas.fetch(m_qatlas, Energy(), OBC(0); Lx=Lx, Ly=Ly)
     E_ref = ε_ref * N   # per-site → total
 
-    @info "Kitaev DMRG vs QAtlas (Lx=Ly=2 OBC isotropic)" N E_dmrg E_ref ε_dmrg =
-        E_dmrg / N ε_ref rel_err = abs(E_dmrg - E_ref) / abs(E_ref)
+    @info "Kitaev DMRG vs QAtlas (Lx=Ly=2 OBC isotropic)" N E_dmrg E_ref ε_dmrg = E_dmrg / N ε_ref rel_err =
+        abs(E_dmrg - E_ref) / abs(E_ref)
     @test E_dmrg ≈ E_ref rtol = 1e-4
 end
 
@@ -75,14 +78,17 @@ end
         (2.0, 0.5, 0.5),     # Ax-phase (gapped)
     ]
     for (Kx, Ky, Kz) in cases
-        lat = build_lattice(L2DHoneycomb, Lx, Ly;
-            boundary=OpenAxis(), layout=UniformLayout(IsingSite()))
-        model = LatticeModel(; lattice=lat,
+        lat = build_lattice(
+            L2DHoneycomb, Lx, Ly; boundary=OpenAxis(), layout=UniformLayout(IsingSite())
+        )
+        model = LatticeModel(;
+            lattice=lat,
             bond_models=Dict(
                 :type_1 => KitaevBond(; K=Kz, axis=:z, site=SiteType("Qubit")),
                 :type_2 => KitaevBond(; K=Kx, axis=:x, site=SiteType("Qubit")),
                 :type_3 => KitaevBond(; K=Ky, axis=:y, site=SiteType("Qubit")),
-            ))
+            ),
+        )
         N = num_sites(lat)
         sites = siteinds("Qubit", N)
         H = MPO(build_opsum(model, sites), sites)

--- a/test/base/test_kitaev_honeycomb.jl
+++ b/test/base/test_kitaev_honeycomb.jl
@@ -3,8 +3,7 @@ using ITensors, ITensorMPS
 using ITensors: SiteType
 using LatticeCore: num_sites, bonds
 using Lattice2D: Honeycomb, build_lattice
-using Lattice2D: PeriodicAxis, OpenAxis, LatticeBoundary, UniformLayout,
-    IsingSite
+using Lattice2D: PeriodicAxis, OpenAxis, LatticeBoundary, UniformLayout, IsingSite
 
 # Smoke test: does LatticeModel + KitaevBond produce a sensible
 # Hamiltonian on Lattice2D's Honeycomb? We check the three-axis Kitaev
@@ -12,16 +11,17 @@ using Lattice2D: PeriodicAxis, OpenAxis, LatticeBoundary, UniformLayout,
 # state energy via DMRG at the isotropic point K_x = K_y = K_z = 1.
 
 function _make_kitaev_honeycomb(Lx::Int, Ly::Int; K=1.0)
-    lat = build_lattice(Honeycomb, Lx, Ly;
-        boundary=OpenAxis(),
-        layout=UniformLayout(IsingSite()))
+    lat = build_lattice(
+        Honeycomb, Lx, Ly; boundary=OpenAxis(), layout=UniformLayout(IsingSite())
+    )
     model = LatticeModel(;
         lattice=lat,
         bond_models=Dict(
             :type_1 => KitaevBond(; K=K, axis=:z, site=SiteType("Qubit")),
             :type_2 => KitaevBond(; K=K, axis=:x, site=SiteType("Qubit")),
             :type_3 => KitaevBond(; K=K, axis=:y, site=SiteType("Qubit")),
-        ))
+        ),
+    )
     return lat, model
 end
 

--- a/test/base/test_kitaev_honeycomb.jl
+++ b/test/base/test_kitaev_honeycomb.jl
@@ -2,26 +2,28 @@ using ITensorModels: KitaevBond, LatticeModel, build_opsum, local_ham_terms
 using ITensors, ITensorMPS
 using ITensors: SiteType
 using LatticeCore: num_sites, bonds
-using Lattice2D: Honeycomb, build_lattice
+using Lattice2D: Honeycomb as L2DHoneycomb, build_lattice
 using Lattice2D: PeriodicAxis, OpenAxis, LatticeBoundary, UniformLayout, IsingSite
+using QAtlas: QAtlas, Energy, OBC
+using Random: MersenneTwister
 
-# Smoke test: does LatticeModel + KitaevBond produce a sensible
-# Hamiltonian on Lattice2D's Honeycomb? We check the three-axis Kitaev
-# Hamiltonian has the expected bond count and yields a negative ground
-# state energy via DMRG at the isotropic point K_x = K_y = K_z = 1.
+# End-to-end integration: LatticeModel + KitaevBond + Lattice2D.Honeycomb
+# constructs the Kitaev honeycomb Hamiltonian; ITensorMPS DMRG then
+# yields a variational ground state that must converge to the exact
+# value supplied by QAtlas.KitaevHoneycomb (whose OBC branch is
+# validated against ED in the QAtlas test suite). Passing this means
+# the LatticeCoreExt bond iteration + KitaevBond axis-dispatch are
+# physically correct.
 
 function _make_kitaev_honeycomb(Lx::Int, Ly::Int; K=1.0)
-    lat = build_lattice(
-        Honeycomb, Lx, Ly; boundary=OpenAxis(), layout=UniformLayout(IsingSite())
-    )
-    model = LatticeModel(;
-        lattice=lat,
+    lat = build_lattice(L2DHoneycomb, Lx, Ly;
+        boundary=OpenAxis(), layout=UniformLayout(IsingSite()))
+    model = LatticeModel(; lattice=lat,
         bond_models=Dict(
             :type_1 => KitaevBond(; K=K, axis=:z, site=SiteType("Qubit")),
             :type_2 => KitaevBond(; K=K, axis=:x, site=SiteType("Qubit")),
             :type_3 => KitaevBond(; K=K, axis=:y, site=SiteType("Qubit")),
-        ),
-    )
+        ))
     return lat, model
 end
 
@@ -35,26 +37,67 @@ end
     @test n_term > 0
 end
 
-@testset "KitaevHoneycomb isotropic DMRG ground energy is negative" begin
-    # Tiny Honeycomb for CI — 2×2 cells = 8 sites.
+@testset "Kitaev honeycomb DMRG matches QAtlas.KitaevHoneycomb OBC (isotropic)" begin
+    # DMRG on the 8-site 2×2 OBC cluster. QAtlas's `fetch(KitaevHoneycomb,
+    # Energy(), OBC; Lx, Ly)` returns per-site GS energy from the
+    # flux-free-sector SVD — verified against dense ED in the QAtlas
+    # test suite. At Lx = Ly = 2 the reference is ε₀ ≈ -0.5832336.
     Lx, Ly = 2, 2
     lat, model = _make_kitaev_honeycomb(Lx, Ly; K=1.0)
     N = num_sites(lat)
-
     sites = siteinds("Qubit", N)
     H = MPO(build_opsum(model, sites), sites)
 
-    ψ0 = random_mps(sites; linkdims=8)
-    sweeps = Sweeps(12)
-    maxdim!(sweeps, 10, 20, 40, 60)
-    cutoff!(sweeps, 1e-10)
-    E, _ = dmrg(H, ψ0, sweeps; outputlevel=0)
+    rng = MersenneTwister(42)
+    ψ0 = random_mps(rng, sites; linkdims=16)
+    sweeps = Sweeps(20)
+    maxdim!(sweeps, 10, 20, 40, 80, 120)
+    cutoff!(sweeps, 1e-12)
+    E_dmrg, _ = dmrg(H, ψ0, sweeps; outputlevel=0)
 
-    @info "Kitaev honeycomb DMRG" Lx Ly N K = 1.0 E E_per_site = E / N
-    # Isotropic Kitaev gs energy per site in the TL is roughly -0.39 (in
-    # units where K = 1). Small OBC systems deviate, but per-site energy
-    # should clearly be in the range (-0.6, -0.1) — i.e. negative and
-    # finite.
-    @test E / N < -0.1
-    @test E / N > -0.6
+    m_qatlas = QAtlas.KitaevHoneycomb(; Kx=1.0, Ky=1.0, Kz=1.0)
+    ε_ref = QAtlas.fetch(m_qatlas, Energy(), OBC(0); Lx=Lx, Ly=Ly)
+    E_ref = ε_ref * N   # per-site → total
+
+    @info "Kitaev DMRG vs QAtlas (Lx=Ly=2 OBC isotropic)" N E_dmrg E_ref ε_dmrg =
+        E_dmrg / N ε_ref rel_err = abs(E_dmrg - E_ref) / abs(E_ref)
+    @test E_dmrg ≈ E_ref rtol = 1e-4
+end
+
+@testset "Kitaev honeycomb DMRG matches QAtlas anisotropic OBC" begin
+    # Anisotropic points — check the KitaevBond axis dispatch is wired
+    # to the right σˣ / σʸ / σᶻ pauli ops. Ax-phase pushes Kx dominant.
+    Lx, Ly = 2, 2
+    cases = [
+        (1.0, 1.0, 1.0),     # B-phase (isotropic, covered above but
+        #                                include as sanity)
+        (0.3, 0.7, 1.0),     # generic anisotropic
+        (2.0, 0.5, 0.5),     # Ax-phase (gapped)
+    ]
+    for (Kx, Ky, Kz) in cases
+        lat = build_lattice(L2DHoneycomb, Lx, Ly;
+            boundary=OpenAxis(), layout=UniformLayout(IsingSite()))
+        model = LatticeModel(; lattice=lat,
+            bond_models=Dict(
+                :type_1 => KitaevBond(; K=Kz, axis=:z, site=SiteType("Qubit")),
+                :type_2 => KitaevBond(; K=Kx, axis=:x, site=SiteType("Qubit")),
+                :type_3 => KitaevBond(; K=Ky, axis=:y, site=SiteType("Qubit")),
+            ))
+        N = num_sites(lat)
+        sites = siteinds("Qubit", N)
+        H = MPO(build_opsum(model, sites), sites)
+
+        rng = MersenneTwister(hash((Kx, Ky, Kz)) & 0xffff)
+        ψ0 = random_mps(rng, sites; linkdims=16)
+        sweeps = Sweeps(25)
+        maxdim!(sweeps, 10, 20, 40, 80, 120)
+        cutoff!(sweeps, 1e-12)
+        E_dmrg, _ = dmrg(H, ψ0, sweeps; outputlevel=0)
+
+        m_qatlas = QAtlas.KitaevHoneycomb(; Kx=Kx, Ky=Ky, Kz=Kz)
+        E_ref = QAtlas.fetch(m_qatlas, Energy(), OBC(0); Lx=Lx, Ly=Ly) * N
+        @info "Kitaev DMRG vs QAtlas (anisotropic)" Kx Ky Kz E_dmrg E_ref rel_err =
+            abs(E_dmrg - E_ref) / abs(E_ref)
+        @test E_dmrg ≈ E_ref rtol = 1e-3
+    end
 end

--- a/test/base/test_kitaev_honeycomb.jl
+++ b/test/base/test_kitaev_honeycomb.jl
@@ -1,0 +1,60 @@
+using ITensorModels: KitaevBond, LatticeModel, build_opsum, local_ham_terms
+using ITensors, ITensorMPS
+using ITensors: SiteType
+using LatticeCore: num_sites, bonds
+using Lattice2D: Honeycomb, build_lattice
+using Lattice2D: PeriodicAxis, OpenAxis, LatticeBoundary, UniformLayout,
+    IsingSite
+
+# Smoke test: does LatticeModel + KitaevBond produce a sensible
+# Hamiltonian on Lattice2D's Honeycomb? We check the three-axis Kitaev
+# Hamiltonian has the expected bond count and yields a negative ground
+# state energy via DMRG at the isotropic point K_x = K_y = K_z = 1.
+
+function _make_kitaev_honeycomb(Lx::Int, Ly::Int; K=1.0)
+    lat = build_lattice(Honeycomb, Lx, Ly;
+        boundary=OpenAxis(),
+        layout=UniformLayout(IsingSite()))
+    model = LatticeModel(;
+        lattice=lat,
+        bond_models=Dict(
+            :type_1 => KitaevBond(; K=K, axis=:z, site=SiteType("Qubit")),
+            :type_2 => KitaevBond(; K=K, axis=:x, site=SiteType("Qubit")),
+            :type_3 => KitaevBond(; K=K, axis=:y, site=SiteType("Qubit")),
+        ))
+    return lat, model
+end
+
+@testset "LatticeModel + KitaevBond on Honeycomb: bond book-keeping" begin
+    Lx, Ly = 2, 2
+    lat, model = _make_kitaev_honeycomb(Lx, Ly)
+
+    n_bond = length(collect(bonds(lat)))
+    n_term = length(local_ham_terms(model, 1:num_sites(lat); boundary=:full))
+    @test n_term == n_bond      # one OpSum per lattice bond
+    @test n_term > 0
+end
+
+@testset "KitaevHoneycomb isotropic DMRG ground energy is negative" begin
+    # Tiny Honeycomb for CI — 2×2 cells = 8 sites.
+    Lx, Ly = 2, 2
+    lat, model = _make_kitaev_honeycomb(Lx, Ly; K=1.0)
+    N = num_sites(lat)
+
+    sites = siteinds("Qubit", N)
+    H = MPO(build_opsum(model, sites), sites)
+
+    ψ0 = random_mps(sites; linkdims=8)
+    sweeps = Sweeps(12)
+    maxdim!(sweeps, 10, 20, 40, 60)
+    cutoff!(sweeps, 1e-10)
+    E, _ = dmrg(H, ψ0, sweeps; outputlevel=0)
+
+    @info "Kitaev honeycomb DMRG" Lx Ly N K = 1.0 E E_per_site = E / N
+    # Isotropic Kitaev gs energy per site in the TL is roughly -0.39 (in
+    # units where K = 1). Small OBC systems deviate, but per-site energy
+    # should clearly be in the range (-0.6, -0.1) — i.e. negative and
+    # finite.
+    @test E / N < -0.1
+    @test E / N > -0.6
+end


### PR DESCRIPTION
## Summary

Adds `KitaevBond` — a directional Ising bond coupling — as the building block for the Kitaev honeycomb model.

```julia
KitaevBond(; K=1.0, axis=:z, site=SiteType("S=1/2"))
# bond_term(m, i, j) -> -K · σ^axis_i σ^axis_j
```

Axis dispatch (`:x`/`:y`/`:z`) via a `kitaev_op` table covering `S=1/2`, `S=1`, `S=3/2`, `Qubit`.

The full Kitaev honeycomb Hamiltonian comes together through `LatticeModel` with no lattice-topology-specific code:

```julia
using ITensorModels, Lattice2D, LatticeCore
lat = build_lattice(Honeycomb, 2, 2; boundary=OpenAxis(), ...)
model = LatticeModel(; lattice=lat, bond_models=Dict(
    :type_1 => KitaevBond(; K=Kz, axis=:z, site=SiteType("Qubit")),
    :type_2 => KitaevBond(; K=Kx, axis=:x, site=SiteType("Qubit")),
    :type_3 => KitaevBond(; K=Ky, axis=:y, site=SiteType("Qubit"))))
H = MPO(build_opsum(model, sites), sites)
```

Lattice2D's Honeycomb already emits three bond types (`:type_1` / `:type_2` / `:type_3`) corresponding to the three hex-bond directions, so Kitaev's three-axis coupling maps 1:1.

## Test plan

- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` → **58 passing** (43 existing + 15 new):
  - `test_kitaev_bond.jl` (5): struct defaults, one-term OpSum, diagonal checks on `|↑↑⟩` and Qubit `|00⟩`, unknown-axis error.
  - `test_kitaev_honeycomb.jl` (2): bond-count book-keeping on `Honeycomb(2,2)`, and a DMRG ground-state-energy sanity bound `-0.6 < E/site < -0.1` at the isotropic point.

## Depends

- #7 (v0.3.0 bump) — cosmetic; can merge in either order.

## Follow-ups (separate PRs)

- QAtlas `KitaevHoneycomb` with analytic GS energy (Majorana integral), spin gap, flux sector reference — for tight DMRG-vs-exact validation.
- Sublattice site-type handling (e.g. Lieb, Kagome with per-sublattice spins).
- Snake / Hilbert-curve ordering helpers for 2D→MPS embedding.