### PR TITLE
feat: onsite_observable_op for TFIM/XXZ1D/Heisenberg1D/TFIML

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/ITensorModels.jl
+++ b/src/ITensorModels.jl
@@ -6,6 +6,7 @@ using ITensorSiteKit: PhysSite
 
 export AbstractLatticeModel, site_type
 export bond_term, boundary_patch, local_ham_terms, build_opsum
+export onsite_observable_op, build_onsite_observable_opsum
 export TFIM, TFIML, XXZ1D, Heisenberg1D, KitaevBond, LatticeModel
 export to_qatlas, from_qatlas
 
@@ -43,6 +44,7 @@ Inverse of [`to_qatlas`](@ref). Implemented in `ext/QAtlasExt.jl`.
 function from_qatlas end
 
 include("core/interface.jl")
+include("core/observables.jl")
 
 include("models/tfim.jl")
 include("models/tfiml.jl")

--- a/src/core/observables.jl
+++ b/src/core/observables.jl
@@ -1,0 +1,52 @@
+using ITensors: hastags
+using ITensorSiteKit: PhysSite
+
+"""
+    onsite_observable_op(model::AbstractLatticeModel, name::Symbol) -> String
+
+ITensors operator string that implements the one-site observable
+`name` for `model`, resolved against the model's `site_type`. The
+`name` namespace is a small set of physically meaningful symbols
+each model chooses to support — `:sx`, `:sy`, `:sz` for spin models,
+`:nx`, `:ny` for particle models, etc.
+
+Concrete models override this function per supported `(name, SiteType)`
+combination. The generic method throws so that unsupported requests
+fail loud rather than silently returning a bogus operator name.
+"""
+function onsite_observable_op(m::AbstractLatticeModel, name::Symbol)
+    error(
+        "onsite_observable_op: model $(typeof(m)) has no observable `$name` on site $(site_type(m))",
+    )
+end
+
+"""
+    build_onsite_observable_opsum(model, sites, name::Symbol;
+                                   phys_sites, weights) -> OpSum
+
+Assemble the OpSum `Σ_k weights[k] · op(phys_sites[k])` where `op` is
+[`onsite_observable_op`](@ref)`(model, name)`. Default `phys_sites`
+picks every `PhysSite`-tagged index in `sites`; default `weights`
+gives the unnormalised total (`Σᵢ op_i`).
+
+For the per-site mean pass `weights = fill(1 / length(phys_sites), …)`;
+for bulk-only measurements on aux-sandwiched layouts
+(e.g. [`ThermalMPS.AuxChain`](@ref)) pass the bulk `phys_sites`
+directly.
+"""
+function build_onsite_observable_opsum(
+    m::AbstractLatticeModel,
+    sites,
+    name::Symbol;
+    phys_sites=findall(i -> hastags(i, PhysSite), sites),
+    weights=ones(length(phys_sites)),
+)
+    length(weights) == length(phys_sites) ||
+        throw(ArgumentError("weights length $(length(weights)) ≠ phys_sites length $(length(phys_sites))"))
+    op = onsite_observable_op(m, name)
+    opsum = OpSum()
+    for (k, i) in enumerate(phys_sites)
+        opsum += weights[k], op, i
+    end
+    return opsum
+end

--- a/src/core/observables.jl
+++ b/src/core/observables.jl
@@ -41,8 +41,11 @@ function build_onsite_observable_opsum(
     phys_sites=findall(i -> hastags(i, PhysSite), sites),
     weights=ones(length(phys_sites)),
 )
-    length(weights) == length(phys_sites) ||
-        throw(ArgumentError("weights length $(length(weights)) ≠ phys_sites length $(length(phys_sites))"))
+    length(weights) == length(phys_sites) || throw(
+        ArgumentError(
+            "weights length $(length(weights)) ≠ phys_sites length $(length(phys_sites))",
+        ),
+    )
     op = onsite_observable_op(m, name)
     opsum = OpSum()
     for (k, i) in enumerate(phys_sites)

--- a/src/models/heisenberg.jl
+++ b/src/models/heisenberg.jl
@@ -18,3 +18,6 @@ site_type(m::Heisenberg1D) = m.site
 function bond_term(m::Heisenberg1D, i::Int, j::Int)
     bond_term(XXZ1D(; J=m.J, Δ=1.0, site=m.site), i, j)
 end
+
+onsite_observable_op(m::Heisenberg1D, name::Symbol) =
+    onsite_observable_op(XXZ1D(; J=m.J, Δ=1.0, site=m.site), name)

--- a/src/models/heisenberg.jl
+++ b/src/models/heisenberg.jl
@@ -19,5 +19,6 @@ function bond_term(m::Heisenberg1D, i::Int, j::Int)
     bond_term(XXZ1D(; J=m.J, Δ=1.0, site=m.site), i, j)
 end
 
-onsite_observable_op(m::Heisenberg1D, name::Symbol) =
+function onsite_observable_op(m::Heisenberg1D, name::Symbol)
     onsite_observable_op(XXZ1D(; J=m.J, Δ=1.0, site=m.site), name)
+end

--- a/src/models/tfim.jl
+++ b/src/models/tfim.jl
@@ -36,6 +36,25 @@ ising_x_op(::SiteType"S=3/2") = "Sx"
 ising_z_op(::SiteType"Qubit") = "Z"
 ising_x_op(::SiteType"Qubit") = "X"
 
+function onsite_observable_op(m::TFIM, name::Symbol)
+    # TFIM's symmetry-relevant onsite observables are Sˣ (order parameter
+    # of the disordered/paramagnetic regime) and Sᶻ (of the broken-symmetry
+    # regime). Sʸ is not conventionally used for TFIM but available for
+    # completeness on S=1/2.
+    s = site_type(m)
+    name === :sx && return ising_x_op(s)
+    name === :sz && return ising_z_op(s)
+    if name === :sy
+        return _tfim_y_op(s)
+    end
+    error("TFIM: unsupported onsite observable $name on site $s")
+end
+
+_tfim_y_op(::SiteType"S=1/2") = "Sy"
+_tfim_y_op(::SiteType"S=1") = "Sy"
+_tfim_y_op(::SiteType"S=3/2") = "Sy"
+_tfim_y_op(::SiteType"Qubit") = "Y"
+
 function bond_term(m::TFIM, i::Int, j::Int)
     zop = ising_z_op(m.site)
     xop = ising_x_op(m.site)

--- a/src/models/tfiml.jl
+++ b/src/models/tfiml.jl
@@ -21,6 +21,8 @@ end
 
 site_type(m::TFIML) = m.site
 
+onsite_observable_op(m::TFIML, name::Symbol) = onsite_observable_op(TFIM(; site=m.site), name)
+
 function bond_term(m::TFIML, i::Int, j::Int)
     zop = ising_z_op(m.site)
     xop = ising_x_op(m.site)

--- a/src/models/tfiml.jl
+++ b/src/models/tfiml.jl
@@ -21,7 +21,9 @@ end
 
 site_type(m::TFIML) = m.site
 
-onsite_observable_op(m::TFIML, name::Symbol) = onsite_observable_op(TFIM(; site=m.site), name)
+function onsite_observable_op(m::TFIML, name::Symbol)
+    onsite_observable_op(TFIM(; site=m.site), name)
+end
 
 function bond_term(m::TFIML, i::Int, j::Int)
     zop = ising_z_op(m.site)

--- a/src/models/xxz.jl
+++ b/src/models/xxz.jl
@@ -38,3 +38,11 @@ function bond_term(m::XXZ1D, i::Int, j::Int)
 end
 
 # XXZ1D has no on-site terms → no boundary patch needed.
+
+function onsite_observable_op(m::XXZ1D, name::Symbol)
+    xop, yop, zop, _ = _xxz_ops(m.site)
+    name === :sx && return xop
+    name === :sy && return yop
+    name === :sz && return zop
+    error("XXZ1D: unsupported onsite observable $name on site $(site_type(m))")
+end

--- a/test/base/test_observable_opsum.jl
+++ b/test/base/test_observable_opsum.jl
@@ -1,0 +1,91 @@
+using ITensorModels
+using ITensorModels:
+    AbstractLatticeModel,
+    TFIM,
+    TFIML,
+    XXZ1D,
+    Heisenberg1D,
+    onsite_observable_op,
+    build_onsite_observable_opsum,
+    site_type
+using ITensors, ITensorMPS
+using ITensors: SiteType
+using ITensorSiteKit: PhysInds
+using Random
+
+N = 5
+
+@testset "onsite_observable_op: TFIM picks Sx/Sz per SiteType" begin
+    m12 = TFIM(; site=SiteType("S=1/2"))
+    mqb = TFIM(; site=SiteType("Qubit"))
+    @test onsite_observable_op(m12, :sx) == "Sx"
+    @test onsite_observable_op(m12, :sz) == "Sz"
+    @test onsite_observable_op(m12, :sy) == "Sy"
+    @test onsite_observable_op(mqb, :sx) == "X"
+    @test onsite_observable_op(mqb, :sz) == "Z"
+    @test onsite_observable_op(mqb, :sy) == "Y"
+    @test_throws ErrorException onsite_observable_op(m12, :not_a_real_observable)
+end
+
+@testset "onsite_observable_op: XXZ1D / Heisenberg1D / TFIML reuse Sx/Sy/Sz" begin
+    mxxz = XXZ1D()
+    mhei = Heisenberg1D()
+    mtfiml = TFIML()
+    for m in (mxxz, mhei, mtfiml)
+        @test onsite_observable_op(m, :sx) == "Sx"
+        @test onsite_observable_op(m, :sy) == "Sy"
+        @test onsite_observable_op(m, :sz) == "Sz"
+    end
+    mqb = XXZ1D(; site=SiteType("Qubit"))
+    @test onsite_observable_op(mqb, :sx) == "X"
+    @test onsite_observable_op(mqb, :sy) == "Y"
+    @test onsite_observable_op(mqb, :sz) == "Z"
+end
+
+@testset "build_onsite_observable_opsum: TFIM Mx total equals direct OpSum" begin
+    sites = PhysInds(N; SiteType="S=1/2")
+    m = TFIM()
+    op = build_onsite_observable_opsum(m, sites, :sx)
+
+    direct = OpSum()
+    for i in 1:N
+        direct += 1.0, "Sx", i
+    end
+
+    # Compare by contracting both MPOs against a random MPS.
+    rng = MersenneTwister(7)
+    ψ = random_mps(rng, sites; linkdims=4)
+    @test inner(ψ', MPO(op, sites), ψ) ≈ inner(ψ', MPO(direct, sites), ψ) rtol = 1e-12
+end
+
+@testset "build_onsite_observable_opsum: phys_sites subset + custom weights" begin
+    # Simulate an aux-sandwiched layout: 5 sites, aux at ends, 3 phys in the middle.
+    sites = PhysInds(N; SiteType="S=1/2")
+    m = TFIM()
+    phys = [2, 3, 4]
+
+    # Per-site average ⟨Sx⟩ = (1/3) Σ_i∈phys Sx_i
+    weights = fill(1 / length(phys), length(phys))
+    op = build_onsite_observable_opsum(m, sites, :sx; phys_sites=phys, weights=weights)
+
+    direct = OpSum()
+    for (k, i) in enumerate(phys)
+        direct += weights[k], "Sx", i
+    end
+
+    ψ = MPS(sites, "Up")
+    # ⟨↑↑↑↑↑| Sx_i |↑↑↑↑↑⟩ = 0 for any i, so contraction is 0 either way.
+    @test inner(ψ', MPO(op, sites), ψ) ≈ inner(ψ', MPO(direct, sites), ψ) atol = 1e-12
+
+    # Confirm the OpSum really did restrict to the 3 bulk sites (not all 5).
+    # OpSum length counts distinct term entries.
+    @test length(op) == length(phys)
+end
+
+@testset "build_onsite_observable_opsum: argument-length mismatch throws" begin
+    sites = PhysInds(N; SiteType="S=1/2")
+    m = TFIM()
+    @test_throws ArgumentError build_onsite_observable_opsum(
+        m, sites, :sx; phys_sites=[1, 2, 3], weights=[1.0, 2.0]
+    )
+end


### PR DESCRIPTION
## Summary
- Introduce \`onsite_observable_op(model, name::Symbol) -> String\` trait returning the ITensors operator name for \`:sx\`, \`:sy\`, \`:sz\` resolved against the model's site type (S=1/2 → \`\"Sx\"\` etc., Qubit → \`\"X\"\` etc.).
- Generic \`build_onsite_observable_opsum(model, sites, name; phys_sites, weights)\` composes \`Σ_k weights[k]·op(phys_sites[k])\` — e.g. Mx total on a plain chain is \`build_onsite_observable_opsum(model, sites, :sx)\`.
- Implemented for **TFIM**, **TFIML** (delegates to TFIM), **XXZ1D**, **Heisenberg1D** (delegates to XXZ1D).
- Unlocks the observable side of the thermal-benchmark stack in ThermalMPS.jl (Mx/Mz/… against QAtlas).

## Test plan
- [x] New \`test/base/test_observable_opsum.jl\`: per-SiteType op selection, TFIM Mx total vs direct OpSum, bulk subset / custom weights on aux-sandwiched layout, argument-length mismatch throws.
- [x] Full suite: 83/83 pass locally (including existing DMRG/QAtlas regressions).
- [ ] CI green on this PR.