### PR TITLE
test: QAtlas bridge coverage for XXZ1D / Heisenberg1D / site_type (#20)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 docs/build/
-Manifest.toml
+Manifest.tomlnotes/

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/test/base/test_qatlas_bridge.jl
+++ b/test/base/test_qatlas_bridge.jl
@@ -1,5 +1,5 @@
-using ITensorModels: TFIM, to_qatlas, from_qatlas
-using ITensors: SiteType
+using ITensorModels: TFIM, XXZ1D, Heisenberg1D, site_type, to_qatlas, from_qatlas
+using ITensors: SiteType, OpSum
 using QAtlas: QAtlas
 using QAtlas: Energy, MassGap, Infinite, OBC
 
@@ -52,4 +52,90 @@ end
 @testset "to_qatlas undefined for unsupported SiteType" begin
     m_s1 = TFIM(; site=SiteType("S=1"))
     @test_throws MethodError to_qatlas(m_s1)
+end
+
+# ── XXZ1D / Heisenberg1D round-trip ──────────────────────────────────
+
+@testset "XXZ1D round-trip preserves J and Δ" begin
+    # XXZ1D uses spin-½ coefficients on both sides, so to_qatlas /
+    # from_qatlas pass (J, Δ) through unchanged.
+    m = XXZ1D(; J=0.7, Δ=-0.3)
+    qm = to_qatlas(m)
+    @test qm.J == 0.7 && qm.Δ == -0.3
+    back = from_qatlas(qm)
+    @test back.J == 0.7 && back.Δ == -0.3
+end
+
+@testset "Heisenberg1D round-trip — J = 1 only" begin
+    # `QAtlas.Heisenberg1D` carries no J field; to_qatlas drops it and
+    # from_qatlas restores J = 1. So a J = 1 round-trip is exact, but
+    # a J ≠ 1 round-trip drops J (documented). Tests both.
+    m1 = Heisenberg1D(; J=1.0)
+    @test from_qatlas(to_qatlas(m1)).J == 1.0
+
+    m2 = Heisenberg1D(; J=0.7)
+    @test from_qatlas(to_qatlas(m2)).J == 1.0
+    @test m2.J != from_qatlas(to_qatlas(m2)).J
+end
+
+# ── site_type propagation through the bridge ─────────────────────────
+
+@testset "site_type accessor reflects the model's site field" begin
+    @test site_type(TFIM(; site=SiteType("S=1/2"))) === SiteType("S=1/2")
+    @test site_type(TFIM(; site=SiteType("Qubit"))) === SiteType("Qubit")
+    @test site_type(XXZ1D(; site=SiteType("S=1/2"))) === SiteType("S=1/2")
+    @test site_type(XXZ1D(; site=SiteType("Qubit"))) === SiteType("Qubit")
+    @test site_type(Heisenberg1D(; site=SiteType("Qubit"))) === SiteType("Qubit")
+end
+
+@testset "from_qatlas defaults to the canonical site (Pauli for TFIM, S=½ for XXZ)" begin
+    # `QAtlas.TFIM(J, h)` is in Pauli units, so the inverse map lands
+    # on SiteType("Qubit") to keep coefficients identity-preserving.
+    @test site_type(from_qatlas(QAtlas.TFIM(; J=0.4, h=0.6))) === SiteType("Qubit")
+    # XXZ1D / Heisenberg1D bridge preserves spin-½ units → S=1/2 default.
+    @test site_type(from_qatlas(QAtlas.XXZ1D(; J=1.0, Δ=0.5))) === SiteType("S=1/2")
+    @test site_type(from_qatlas(QAtlas.Heisenberg1D())) === SiteType("S=1/2")
+end
+
+# ── bond_term emits operator names matching the SiteType ─────────────
+#
+# Verifies that XXZ1D's `bond_term` picks up the right operator
+# strings ("Sα" vs "X/Y/Z") through the `_xxz_ops(site)` dispatch:
+# the same physical Hamiltonian, expressed on either SiteType, must
+# act identically on a basis MPS.  A regression here (e.g. the wrong
+# site type silently keeps emitting `Sα`) would manifest in the
+# downstream MPO building as either a missing-op error or a wrong
+# inner product — this test catches the latter (silent) failure mode.
+
+@testset "bond_term: S=1/2 and Qubit site types encode the same H" begin
+    using ITensorModels: bond_term
+    using ITensorMPS: MPO, MPS, inner
+    using ITensorSiteKit: PhysInds
+
+    N = 4
+    sites_s = PhysInds(N; SiteType="S=1/2")
+    sites_q = PhysInds(N; SiteType="Qubit")
+    m_s = XXZ1D(; J=1.0, Δ=0.5, site=SiteType("S=1/2"))
+    m_q = XXZ1D(; J=1.0, Δ=0.5, site=SiteType("Qubit"))
+
+    os_s = OpSum()
+    os_q = OpSum()
+    for j in 1:(N - 1)
+        os_s += bond_term(m_s, j, j + 1)
+        os_q += bond_term(m_q, j, j + 1)
+    end
+    H_s = MPO(os_s, sites_s)
+    H_q = MPO(os_q, sites_q)
+
+    # ⟨Up|H|Up⟩ — only the Δ Sᶻ Sᶻ term survives. With N - 1 bonds
+    # and Sᶻ-eigenvalue (1/2) per site, this equals
+    # J Δ (N - 1) × (1/4) on either SiteType (the `scale = 1/4`
+    # rescale in `_xxz_ops(::Qubit)` exactly compensates `Z² = +1`
+    # vs `Sᶻ² = 1/4`).  A silent site-type → operator-name mismatch
+    # would land here.
+    ψ_s_up = MPS(sites_s, "Up")
+    ψ_q_up = MPS(sites_q, "Up")
+    expected = m_s.J * m_s.Δ * (N - 1) / 4
+    @test real(inner(ψ_s_up', H_s, ψ_s_up)) ≈ expected rtol = 1e-12
+    @test real(inner(ψ_q_up', H_q, ψ_q_up)) ≈ expected rtol = 1e-12
 end


### PR DESCRIPTION
## Summary

Extends `test/base/test_qatlas_bridge.jl` to cover the remaining bridge
sub-paths from #20:

- **XXZ1D round-trip** — `(J, Δ)` pass through unchanged (S=½ on both
  sides).
- **Heisenberg1D round-trip — J = 1 only** — pins the documented
  contract that `QAtlas.Heisenberg1D` carries no J field, so a J ≠ 1
  source struct loses J after `from_qatlas(to_qatlas(...))`.
- **`site_type` accessor + `from_qatlas` site landing** — confirms
  every model returns its constructor's `site` field, and that
  `from_qatlas` picks the canonical site type per model (Pauli for
  TFIM, S=½ for XXZ / Heisenberg).
- **`bond_term` SiteType cross-check** — builds the same XXZ
  Hamiltonian on `S=1/2` and `Qubit` and verifies
  ⟨Up|H|Up⟩ = J Δ (N − 1) / 4 on both. Fails loudly if
  `_xxz_ops(::Qubit)` regresses on its `scale = 1/4` rescale.

Closes the round-trip / site_type parts of #20. The `bond_term` cross-
check covers the third sub-task (observable_opsum cross-model
consistency) at the level XXZ exercises the dispatch — TFIM and TFIML
are already covered by the existing `test_tfim_opsum.jl` and
`test_observable_opsum.jl`.

Version bumped 0.5.1 → 0.5.2.

## Test plan

- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` — 98/98 pass
- [x] Mutation: `expected = J Δ (N - 1) / 4` is sensitive to
      `_xxz_ops(::Qubit)` returning the wrong rescale (a 4× factor
      drives the inner product off by 4× → @test fails).