### PR TITLE
chore(compat): bump QAtlas to 0.18 (consolidates #26, #27)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ ITensorMPS = "0.3, 0.4"
 ITensorSiteKit = "0.1"
 ITensors = "0.9"
 LatticeCore = "0.8, 0.10"
-QAtlas = "0.13, 0.14, 0.15"
+QAtlas = "0.13, 0.14, 0.15, 0.18"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
Replaces #26 and #27 with a single PR rebased onto current main. Same one-line bump.