### PR TITLE
feat(modulation): #1 foundation - ND envelope primitives

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/docs/src/design/modulation_nd.md
+++ b/docs/src/design/modulation_nd.md
@@ -1,0 +1,202 @@
+# ND Modulation — Formalism & API
+
+Status: agreed 2026-05-12. This document describes the formalism
+for the ND modulation extension implemented across the
+`feat/modulation-2d-*` PR chain. Each section is labelled with the
+PR that introduces the corresponding code.
+
+## Goal
+
+Lift the existing 1D `AbstractModulation` machinery
+(`SSD`, `SinPower{N}`, `SmoothBoundary`, `Tabulated`, `ModulatedModel`)
+to arbitrary-dimensional lattices (honeycomb, square, triangular, …)
+without disturbing the 1D code path.
+
+## Geometry of an envelope
+
+An envelope `f : ℝ^D → [0, 1]` is decomposed as
+
+```
+f(r) = g( d(r ; r_c) )
+```
+
+where
+
+- `r_c ∈ ℝ^D` is a **center** (see `AbstractCenter`),
+- `d : ℝ^D → ℝ_+` (or `ℝ^D → ℝ_+^D` for the axis-product variant) is a
+  **distance metric** (see `AbstractDistance`),
+- `g : ℝ_+ → [0, 1]` (or `g : ℝ_+^D → [0, 1]` for axis-product) is a
+  **profile** (see `AbstractProfile`).
+
+The `AxisProductDistance` path treats each axis independently and
+combines per-axis profiles by `f(r) = Π_d g(d_d; R_d)` — this recovers
+the LatticeCore-style hypercubic SSD `Π_d sin²(π (c_d − 1/2) / L_d)`.
+
+## Type hierarchy
+
+```
+AbstractModulation                                  # existing (1D)
+└── AbstractModulationND                            # new
+
+AbstractCenter
+├── GeometricCenter                                 # mean of positions
+├── BoundingBoxCenter                               # (min + max) / 2 per axis
+└── ExplicitCenter(r_c::SVector{D,T})
+
+AbstractDistance
+├── EuclideanDistance                               # ‖r − r_c‖₂      (sphere)
+├── AxialDistance(axis::Int)                        # |r[a] − r_c[a]| (cylinder axial)
+├── PerpendicularDistance(axis::Int)                # ‖r[¬a] − r_c[¬a]‖₂ (cylinder radial)
+└── AxisProductDistance                             # NTuple (|r[d] − r_c[d]|)_d
+
+AbstractProfile
+├── SinSquareProfile(R)        # = 1 − sin²(π d / (2R))  ≡ cos²(π d / (2R))
+├── SinPowerProfile{N}(R)      # = 1 − sin^N(π d / (2R))   ← N=2 ⇒ SinSquare
+└── CosineRampProfile(R, edge) # plateau + cosine ramp (Vekic–White on a disk)
+
+RadialEnvelope{C,D,P} <: AbstractModulationND        # composition wrapper
+    center::C
+    distance::D
+    profile::P
+```
+
+For `AxisProductDistance` the profile carries an `SVector` of per-axis
+radii, e.g. `SinSquareProfile(SVector(Rx, Ry))`.
+
+## Profile formulas
+
+The profile `g` is defined so that **`g(0) = 1`**, **`g(R) = 0`**, and
+`g(d) = 0` for `d > R`.
+
+### SinSquare
+
+```math
+g(d) =
+\begin{cases}
+1 - \sin^2(\pi d / (2R)) & 0 \le d \le R \
+0 & d > R
+\end{cases}
+\;\;\equiv\;\; \cos^2(\pi d / (2R)) \;\; \text{on } [0, R]
+```
+
+### SinPower{N}
+
+```math
+g(d) =
+\begin{cases}
+1 - \sin^N(\pi d / (2R)) & 0 \le d \le R \
+0 & d > R
+\end{cases}
+```
+
+- `N = 2` reduces to `SinSquare`.
+- Larger `N` makes the bulk plateau **wider** and the boundary fall-off
+  steeper — the radial counterpart of `sin^N(π i / L)` in 1D.
+- **Not** `cos^N`. The naive radial transliteration `g(d) = cos^N(π d/(2R))`
+  reverses the semantics (larger `N` makes the bulk shrink); the
+  `1 − sin^N` form preserves the 1D meaning.
+
+### CosineRamp(R, edge)
+
+```math
+g(d) =
+\begin{cases}
+1 & d \le R - \mathrm{edge} \
+\frac{1 + \cos(\pi (d - (R - \mathrm{edge})) / \mathrm{edge})}{2}
+                                & R - \mathrm{edge} < d < R \
+0 & d \ge R
+\end{cases}
+```
+
+Generalises Vekic–White smooth boundary conditions to a disk / hyper-ball.
+
+## Evaluation contract
+
+For a lattice `lat` of `AbstractLattice{D,T}`:
+
+```
+center_position(c::AbstractCenter, lat) -> SVector{D,T}
+distance_at(d::AbstractDistance, lat, k::Int, r_c::SVector) -> Real (or NTuple{D,Real})
+profile_value(p::AbstractProfile, d::Real) -> Float64
+profile_value(p::AbstractProfile, ds::NTuple{D,Real}) -> Float64   # axis-product only
+site_envelope(env::RadialEnvelope, lat, k::Int) -> Float64
+```
+
+### Site weight
+
+```
+site_weight(env, lat, k) = site_envelope(env, lat, k)
+                        = profile_value(env.profile, distance_at(env.distance, lat, k, r_c))
+```
+
+### Bond weight (★ midpoint evaluation)
+
+```
+bond_weight(env, lat, i, j) = profile_value(
+    env.profile,
+    distance_at_position(env.distance, (position(lat,i) + position(lat,j)) / 2, r_c),
+)
+```
+
+The midpoint convention matches the existing 1D rule
+`bond_weight(SSD, i, L) = sin²(π i / L)` (site is at half-integer `i − 1/2`,
+bond midpoint at integer `i`). This **differs** from LatticeCore's
+`bond_weight(::SSD, lat, i, j) = (f(r_i) + f(r_j))/2`; the two agree to
+leading order for smooth envelopes but disagree on the strict numerics.
+
+## Hamiltonian assembly (`ModulatedLatticeModel`)
+
+```
+local_ham_terms(m::ModulatedLatticeModel{LatticeModel,Env}, _; boundary=:full):
+    terms = OpSum[]
+    for b in bonds(m.base.lattice):
+        push!(terms, bond_weight(env, lat, b.i, b.j)
+                     * bond_coupling_term(submodel(b), ord[b.i], ord[b.j]))
+    for k in 1:num_sites(m.base.lattice):
+        push!(terms, site_weight(env, lat, k)
+                     * onsite_term(submodel_for_site(k), ord[k]))
+    return terms
+```
+
+ND Hamiltonian assembly **fully separates** bond coupling from on-site
+terms — there is no half-distribution and no `boundary_patch` step. This
+works for any coordination number and is the principled generalisation
+of the 1D protocol.
+
+The 1D `ModulatedModel` is **not modified**; it keeps the
+half-distribution + boundary_patch convention. A regression test
+checks that `ModulatedLatticeModel(line_lattice(L), radial_ssd_1d)`
+produces an `OpSum` equal (up to operator-algebra normalisation) to
+`ModulatedModel(TFIM(), L, SSD())`.
+
+## Factories (user-facing)
+
+```julia
+rectangular_ssd(lat; profile=SinSquareProfile, kwargs...)        # axis-product (LatticeCore SSD)
+cylindrical_ssd(lat; axis=1, profile=SinSquareProfile, kwargs...) # axial; uniform on the cylinder
+spherical_ssd(lat; radius=:inscribed, profile=SinSquareProfile, kwargs...)
+spherical_sin_power(lat, N; radius=:inscribed)
+spherical_smooth(lat; edge, radius=:inscribed)
+```
+
+The `radius` keyword chooses between `:inscribed` (`min(L_d)/2`) and
+`:circumscribed` (`‖(L_d / 2)‖₂`).
+
+## File plan
+
+- `src/core/modulation_nd.jl` — new file, all primitives + `RadialEnvelope`
+- `src/models/modulated_lattice.jl` — `ModulatedLatticeModel` wrapper
+- `ext/LatticeCoreExt.jl` — extend `local_ham_terms` for `ModulatedLatticeModel`
+- `src/ITensorModels.jl` — add includes + exports
+- `test/base/test_modulation_nd.jl` — unit tests for primitives + 1D regression
+- `test/base/test_modulated_lattice.jl` — Hamiltonian build on honeycomb / square
+
+## Decision log (agreed 2026-05-12)
+
+- (D1) `SinPower` formula: `1 − sin^N(π d / (2R))` (preserves 1D semantics).
+- (D2) `bond_weight` evaluated at the **bond midpoint** position.
+- (D3) ND `ModulatedLatticeModel` **fully separates** bond / onsite emission.
+- (D4) `AxisProductDistance` carries per-axis radii via `SVector`.
+- (D5) `AxisProductDistance` is a distinct path; not composable with
+   `EuclideanDistance` / `AxialDistance` in the same envelope.
+- (D6) Profile sweeping over multiple distance types: deferred.

--- a/src/ITensorModels.jl
+++ b/src/ITensorModels.jl
@@ -12,6 +12,13 @@ export TFIM, TFIML, XXZ1D, Heisenberg1D, KitaevBond, LatticeModel
 export AbstractModulation, Uniform, SSD, SinPower, SmoothBoundary, Tabulated
 export site_weight, bond_weight
 export ModulatedModel, modulated
+export AbstractModulationND
+export AbstractCenter, GeometricCenter, BoundingBoxCenter, ExplicitCenter
+export AbstractDistance, EuclideanDistance, AxialDistance, PerpendicularDistance,
+    AxisProductDistance
+export AbstractProfile, SinSquareProfile, SinPowerProfile, CosineRampProfile
+export RadialEnvelope
+export distance_at_position, distance_at, center_position, profile_value, site_envelope
 export to_qatlas, from_qatlas
 
 """
@@ -50,6 +57,7 @@ function from_qatlas end
 include("core/interface.jl")
 include("core/observables.jl")
 include("core/modulation.jl")
+include("core/modulation_nd.jl")
 
 include("models/tfim.jl")
 include("models/tfiml.jl")

--- a/src/ITensorModels.jl
+++ b/src/ITensorModels.jl
@@ -14,8 +14,8 @@ export site_weight, bond_weight
 export ModulatedModel, modulated
 export AbstractModulationND
 export AbstractCenter, GeometricCenter, BoundingBoxCenter, ExplicitCenter
-export AbstractDistance, EuclideanDistance, AxialDistance, PerpendicularDistance,
-    AxisProductDistance
+export AbstractDistance,
+    EuclideanDistance, AxialDistance, PerpendicularDistance, AxisProductDistance
 export AbstractProfile, SinSquareProfile, SinPowerProfile, CosineRampProfile
 export RadialEnvelope
 export distance_at_position, distance_at, center_position, profile_value, site_envelope

--- a/src/core/modulation_nd.jl
+++ b/src/core/modulation_nd.jl
@@ -1,0 +1,365 @@
+# ND modulation envelopes — primitives for honeycomb / square / kagome / ...
+# See `notes/plot_modulation/DESIGN.md` for the formalism agreed on
+# 2026-05-12.
+
+"""
+    AbstractModulationND <: AbstractModulation
+
+ND extension of [`AbstractModulation`](@ref). ND modulations expose
+
+    site_weight(mod, lat, k::Int)         ::Float64
+    bond_weight(mod, lat, i::Int, j::Int) ::Float64
+
+dispatching on the lattice and a single site/bond index, rather than on
+the `(i, L)` chain coordinates used by the 1D protocol. The two
+signature families share `AbstractModulation` as their supertype but
+are otherwise independent — existing 1D code is unaffected.
+
+Lattice-bound evaluation methods (`center_position`, `distance_at`,
+`site_weight(::AbstractModulationND, lat, k)`, …) live in the
+`LatticeCoreExt` extension so that the core module stays free of a
+`LatticeCore` dependency.
+"""
+abstract type AbstractModulationND <: AbstractModulation end
+
+# ---------------------------------------------------------------------
+# Center
+# ---------------------------------------------------------------------
+
+"""
+    AbstractCenter
+
+Strategy for choosing the envelope's center `r_c ∈ ℝ^D`. Concrete
+subtypes implement `center_position(c, lat) -> SVector{D, T}` in the
+`LatticeCoreExt` extension.
+"""
+abstract type AbstractCenter end
+
+"""
+    GeometricCenter()
+
+Center at the arithmetic mean of all site positions,
+`r_c = (1/N) Σ_k r_k`.
+"""
+struct GeometricCenter <: AbstractCenter end
+
+"""
+    BoundingBoxCenter()
+
+Center at the midpoint of the lattice's axis-aligned bounding box,
+`r_c = (min(r_k) + max(r_k)) / 2` per axis.
+"""
+struct BoundingBoxCenter <: AbstractCenter end
+
+"""
+    ExplicitCenter(r_c)
+
+Use the user-supplied vector `r_c` as the envelope center. Accepts any
+indexable container (`SVector`, `Vector`, tuple).
+"""
+struct ExplicitCenter{V} <: AbstractCenter
+    r::V
+end
+
+# ---------------------------------------------------------------------
+# Distance
+# ---------------------------------------------------------------------
+
+"""
+    AbstractDistance
+
+Distance metric carried by a [`RadialEnvelope`](@ref). Concrete subtypes
+implement `distance_at_position(d, r, r_c)` (lattice-free) **or**
+`distance_at(d, lat, k, r_c)` (lattice-bound, in `LatticeCoreExt`).
+The return value is either a `Real` or an `NTuple{D, Real}` (the latter
+only for [`AxisProductDistance`](@ref)).
+"""
+abstract type AbstractDistance end
+
+"""
+    EuclideanDistance()
+
+`d(r) = ‖r − r_c‖₂`. Use for spherical / hyper-spherical envelopes.
+"""
+struct EuclideanDistance <: AbstractDistance end
+
+"""
+    AxialDistance(axis::Int)
+
+`d(r) = |r[axis] − r_c[axis]|`. Single-axis distance — produces a slab-
+shaped envelope that is uniform in every other direction, the natural
+generalisation of 1D SSD along one axis of a cylinder.
+"""
+struct AxialDistance <: AbstractDistance
+    axis::Int
+end
+
+"""
+    PerpendicularDistance(axis::Int)
+
+`d(r) = ‖r[¬axis] − r_c[¬axis]‖₂`. Distance restricted to the
+hyperplane orthogonal to `axis`. Produces a tube-shaped envelope along
+`axis` — the canonical cylindrical SSD when `axis` is the cylinder
+axis.
+"""
+struct PerpendicularDistance <: AbstractDistance
+    axis::Int
+end
+
+"""
+    AxisProductDistance()
+
+Per-axis tuple `d = (|r[1] − r_c[1]|, …, |r[D] − r_c[D]|)`. Combined
+with a profile carrying per-axis radii this recovers the LatticeCore
+hypercubic SSD `Π_d sin²(π (c_d − 1/2) / L_d)`.
+
+`AxisProductDistance` is a distinct evaluation path: the matching
+[`profile_value`](@ref) overload takes a tuple of per-axis distances
+and reduces by product. It cannot be composed with the scalar profile
+methods used by [`EuclideanDistance`](@ref) /
+[`AxialDistance`](@ref) / [`PerpendicularDistance`](@ref).
+"""
+struct AxisProductDistance <: AbstractDistance end
+
+"""
+    distance_at_position(dist::AbstractDistance, r, r_c) -> Real or NTuple
+
+Evaluate the distance metric at a generic position `r` (not necessarily
+a lattice site). Used both for site-resolved evaluation (`r = r_k`) and
+midpoint-evaluated bond weights (`r = (r_i + r_j) / 2`).
+
+The lattice-bound variant `distance_at(dist, lat, k, r_c)` is the one
+implementations of `site_weight` / `bond_weight` typically call; it
+defers to `distance_at_position(dist, position(lat, k), r_c)` and lives
+in `LatticeCoreExt` together with the `LatticeCore` import.
+"""
+function distance_at_position end
+
+# Pure-vector implementations (no lattice). Generic over indexable
+# coordinate containers (`SVector`, `Vector`, `Tuple`, …) so they work
+# from both the core module and the extension.
+
+function distance_at_position(::EuclideanDistance, r, r_c)
+    s = zero(_promote_real(r, r_c))
+    @inbounds for d in eachindex(r)
+        δ = r[d] - r_c[d]
+        s += δ * δ
+    end
+    return sqrt(s)
+end
+
+function distance_at_position(d::AxialDistance, r, r_c)
+    return abs(r[d.axis] - r_c[d.axis])
+end
+
+function distance_at_position(d::PerpendicularDistance, r, r_c)
+    a = d.axis
+    s = zero(_promote_real(r, r_c))
+    @inbounds for k in eachindex(r)
+        k == a && continue
+        δ = r[k] - r_c[k]
+        s += δ * δ
+    end
+    return sqrt(s)
+end
+
+function distance_at_position(::AxisProductDistance, r, r_c)
+    return ntuple(d -> abs(r[d] - r_c[d]), length(r))
+end
+
+@inline function _promote_real(r, r_c)
+    T = promote_type(eltype(r), eltype(r_c))
+    return float(zero(T))
+end
+
+# ---------------------------------------------------------------------
+# Profile
+# ---------------------------------------------------------------------
+
+"""
+    AbstractProfile
+
+1D shape function `g : ℝ₊ → [0, 1]` (or `ℝ₊^D → [0, 1]` for the
+axis-product path) controlling how the envelope decays away from the
+center. Concrete subtypes satisfy `g(0) = 1`, `g(R) = 0`, and `g(d) = 0`
+for `d > R`.
+"""
+abstract type AbstractProfile end
+
+"""
+    SinSquareProfile(R)
+
+`g(d) = 1 − sin²(π d / (2R)) ≡ cos²(π d / (2R))` on `[0, R]`, zero
+outside. The canonical SSD profile.
+"""
+struct SinSquareProfile{R} <: AbstractProfile
+    R::R
+end
+
+"""
+    SinPowerProfile{N}(R)
+
+`g(d) = 1 − sin^N(π d / (2R))` on `[0, R]`, zero outside. Reduces to
+[`SinSquareProfile`](@ref) at `N = 2`. Larger `N` widens the bulk
+plateau and sharpens the boundary fall-off — the radial counterpart of
+the 1D `sin^N(π i / L)` envelope used in Hotta–Shibata-style sin-power
+modulations.
+
+Defined as `1 − sin^N` rather than the naive `cos^N`: the naive form
+flips the semantics of `N` (larger `N` would shrink the bulk plateau).
+See `notes/plot_modulation/DESIGN.md` for the worked-out comparison.
+"""
+struct SinPowerProfile{N,R} <: AbstractProfile
+    R::R
+end
+
+SinPowerProfile{N}(R::T) where {N,T} = SinPowerProfile{N,T}(R)
+
+"""
+    CosineRampProfile(R, edge)
+
+`g(d)` equals `1` on `[0, R − edge]`, falls through a half-cosine ramp
+to `0` on `[R − edge, R]`, and is zero on `[R, ∞)`. Generalises
+Vekic–White smooth boundary conditions to a disk / hyper-ball.
+
+Currently only supported with scalar `AbstractDistance` (Euclidean /
+Axial / Perpendicular). Axis-product variant is deferred.
+"""
+struct CosineRampProfile{R,E} <: AbstractProfile
+    R::R
+    edge::E
+end
+
+# ---------------------------------------------------------------------
+# profile_value
+# ---------------------------------------------------------------------
+
+"""
+    profile_value(p::AbstractProfile, d::Real)         -> Float64
+    profile_value(p::AbstractProfile, ds::Tuple{...}) -> Float64
+
+Apply the profile to a scalar distance (Euclidean / Axial /
+Perpendicular path) or a tuple of per-axis distances (`AxisProduct`
+path). The tuple methods expect `p.R` to be an indexable container of
+per-axis radii.
+"""
+function profile_value end
+
+function profile_value(p::SinSquareProfile, d::Real)
+    R = float(p.R)
+    d >= R && return 0.0
+    return 1 - sin(pi * d / (2R))^2
+end
+
+function profile_value(p::SinPowerProfile{N}, d::Real) where {N}
+    R = float(p.R)
+    d >= R && return 0.0
+    return 1 - sin(pi * d / (2R))^N
+end
+
+function profile_value(p::CosineRampProfile, d::Real)
+    R = float(p.R)
+    e = float(p.edge)
+    d >= R && return 0.0
+    d <= R - e && return 1.0
+    return (1 + cos(pi * (d - (R - e)) / e)) / 2
+end
+
+# AxisProduct path: distance is a tuple, profile carries per-axis radii.
+
+function profile_value(p::SinSquareProfile, ds::Tuple{Vararg{Real}})
+    val = 1.0
+    @inbounds for d in eachindex(ds)
+        val *= _axis_sin_square(ds[d], float(p.R[d]))
+    end
+    return val
+end
+
+function profile_value(p::SinPowerProfile{N}, ds::Tuple{Vararg{Real}}) where {N}
+    val = 1.0
+    @inbounds for d in eachindex(ds)
+        val *= _axis_sin_power(ds[d], float(p.R[d]), N)
+    end
+    return val
+end
+
+function profile_value(::CosineRampProfile, ::Tuple{Vararg{Real}})
+    error(
+        "CosineRampProfile combined with AxisProductDistance is not " *
+        "supported yet. Use SinSquareProfile or SinPowerProfile for " *
+        "axis-product envelopes, or pick a scalar distance metric " *
+        "(EuclideanDistance / AxialDistance / PerpendicularDistance) " *
+        "for the cosine ramp.",
+    )
+end
+
+@inline function _axis_sin_square(d::Real, R::Real)
+    d >= R && return 0.0
+    return 1 - sin(pi * d / (2R))^2
+end
+
+@inline function _axis_sin_power(d::Real, R::Real, N::Integer)
+    d >= R && return 0.0
+    return 1 - sin(pi * d / (2R))^N
+end
+
+# ---------------------------------------------------------------------
+# RadialEnvelope
+# ---------------------------------------------------------------------
+
+"""
+    RadialEnvelope(center, distance, profile)
+
+Composition of (center × distance × profile) producing an
+`AbstractModulationND` envelope:
+
+```
+f(r) = profile_value(profile, distance_at_position(distance, r, center_position(center, lat)))
+```
+
+Site and bond weights are derived as
+
+```
+site_weight(env, lat, k)    = f(position(lat, k))
+bond_weight(env, lat, i, j) = f((position(lat, i) + position(lat, j)) / 2)   # midpoint
+```
+
+The midpoint convention for `bond_weight` matches the existing 1D
+`bond_weight(SSD, i, L) = sin²(π i / L)` rule (site at half-integer
+`i − 1/2`, bond at integer `i`).
+"""
+struct RadialEnvelope{C<:AbstractCenter,D<:AbstractDistance,P<:AbstractProfile} <:
+       AbstractModulationND
+    center::C
+    distance::D
+    profile::P
+end
+
+"""
+    site_envelope(env::RadialEnvelope, lat, k::Int) -> Float64
+
+Combined evaluation: `profile_value(env.profile, distance_at(env.distance, lat, k, r_c))`,
+where `r_c = center_position(env.center, lat)`. The implementation
+lives in `LatticeCoreExt` because it touches `position(lat, k)`.
+"""
+function site_envelope end
+
+# `center_position` and `distance_at` are declared (no methods) so that
+# the extension can add lattice-bound methods without piracy.
+
+"""
+    center_position(center::AbstractCenter, lat) -> SVector{D, T}
+
+Resolve the envelope center to a concrete real-space vector. Methods
+live in `LatticeCoreExt`.
+"""
+function center_position end
+
+"""
+    distance_at(dist::AbstractDistance, lat, k::Int, r_c) -> Real or NTuple
+
+Evaluate the distance metric at lattice site `k`. Defers to
+`distance_at_position(dist, position(lat, k), r_c)`; method lives in
+`LatticeCoreExt`.
+"""
+function distance_at end

--- a/test/base/test_modulation_nd_core.jl
+++ b/test/base/test_modulation_nd_core.jl
@@ -1,0 +1,125 @@
+using ITensorModels
+using Test
+
+@testset "RadialEnvelope: type construction" begin
+    env = RadialEnvelope(
+        BoundingBoxCenter(),
+        EuclideanDistance(),
+        SinSquareProfile(3.0),
+    )
+    @test env isa RadialEnvelope
+    @test env isa AbstractModulationND
+    @test env isa AbstractModulation
+    @test env.center isa BoundingBoxCenter
+    @test env.distance isa EuclideanDistance
+    @test env.profile isa SinSquareProfile
+end
+
+@testset "Center constructors" begin
+    @test GeometricCenter() isa AbstractCenter
+    @test BoundingBoxCenter() isa AbstractCenter
+    @test ExplicitCenter([1.0, 2.0]) isa AbstractCenter
+    @test ExplicitCenter((1.0, 2.0)).r == (1.0, 2.0)
+end
+
+@testset "Distance constructors" begin
+    @test EuclideanDistance() isa AbstractDistance
+    @test AxialDistance(1) isa AbstractDistance
+    @test AxialDistance(1).axis == 1
+    @test PerpendicularDistance(2).axis == 2
+    @test AxisProductDistance() isa AbstractDistance
+end
+
+@testset "distance_at_position: Euclidean" begin
+    @test distance_at_position(EuclideanDistance(), [0.0, 0.0], [0.0, 0.0]) ≈ 0.0
+    @test distance_at_position(EuclideanDistance(), [3.0, 4.0], [0.0, 0.0]) ≈ 5.0
+    @test distance_at_position(EuclideanDistance(), [1.0, 1.0], [-1.0, -1.0]) ≈ 2sqrt(2)
+    @test distance_at_position(EuclideanDistance(), (1.0, 0.0, 0.0), (0.0, 0.0, 0.0)) ≈ 1.0
+end
+
+@testset "distance_at_position: Axial" begin
+    @test distance_at_position(AxialDistance(1), [3.0, 4.0], [0.0, 0.0]) ≈ 3.0
+    @test distance_at_position(AxialDistance(2), [3.0, 4.0], [0.0, 0.0]) ≈ 4.0
+    @test distance_at_position(AxialDistance(2), [3.0, 4.0], [0.0, 6.0]) ≈ 2.0
+end
+
+@testset "distance_at_position: Perpendicular" begin
+    # In 2D, perpendicular distance to axis 1 is |Δr[2]|.
+    @test distance_at_position(PerpendicularDistance(1), [3.0, 4.0], [0.0, 0.0]) ≈ 4.0
+    # In 3D, perpendicular to axis 3 is sqrt(Δr[1]^2 + Δr[2]^2).
+    @test distance_at_position(PerpendicularDistance(3), [3.0, 4.0, 5.0], [0.0, 0.0, 0.0]) ≈ 5.0
+    @test distance_at_position(PerpendicularDistance(2), [3.0, 4.0, 5.0], [0.0, 0.0, 0.0]) ≈
+        sqrt(3.0^2 + 5.0^2)
+end
+
+@testset "distance_at_position: AxisProduct" begin
+    ds = distance_at_position(AxisProductDistance(), [3.0, 4.0], [0.0, 0.0])
+    @test ds == (3.0, 4.0)
+    ds2 = distance_at_position(AxisProductDistance(), [3.0, -4.0, 5.0], [1.0, 2.0, 0.0])
+    @test ds2 == (2.0, 6.0, 5.0)
+end
+
+@testset "profile_value: SinSquareProfile" begin
+    p = SinSquareProfile(4.0)
+    @test profile_value(p, 0.0) ≈ 1.0
+    @test profile_value(p, 4.0) ≈ 0.0
+    @test profile_value(p, 8.0) ≈ 0.0    # outside R clipped to 0
+    # cos²(π/8) at d = R/2 = 2
+    @test profile_value(p, 2.0) ≈ cos(pi / 4)^2 ≈ 0.5
+end
+
+@testset "profile_value: SinPowerProfile{N}" begin
+    p2 = SinPowerProfile{2}(4.0)
+    p4 = SinPowerProfile{4}(4.0)
+    p8 = SinPowerProfile{8}(4.0)
+    pss = SinSquareProfile(4.0)
+    # N=2 ≡ SinSquare.
+    for d in [0.0, 0.5, 1.0, 2.0, 3.0, 4.0]
+        @test profile_value(p2, d) ≈ profile_value(pss, d)
+    end
+    # Boundary and center.
+    @test profile_value(p4, 0.0) ≈ 1.0
+    @test profile_value(p4, 4.0) ≈ 0.0
+    @test profile_value(p4, 5.0) ≈ 0.0    # outside R clipped
+    # Larger N => wider central plateau, i.e. value(p4, d) >= value(p2, d) on (0, R).
+    for d in [0.5, 1.0, 1.5, 2.0]
+        @test profile_value(p4, d) >= profile_value(p2, d)
+        @test profile_value(p8, d) >= profile_value(p4, d)
+    end
+end
+
+@testset "profile_value: CosineRampProfile" begin
+    p = CosineRampProfile(10.0, 3.0)
+    # Plateau region [0, R - edge] = [0, 7].
+    @test profile_value(p, 0.0) ≈ 1.0
+    @test profile_value(p, 5.0) ≈ 1.0
+    @test profile_value(p, 7.0) ≈ 1.0
+    # Boundary.
+    @test profile_value(p, 10.0) ≈ 0.0
+    @test profile_value(p, 15.0) ≈ 0.0
+    # Midpoint of ramp (d = 8.5, halfway through the ramp): value = 0.5.
+    @test profile_value(p, 8.5) ≈ 0.5
+end
+
+@testset "profile_value: AxisProduct path" begin
+    p = SinSquareProfile([4.0, 6.0])
+    @test profile_value(p, (0.0, 0.0)) ≈ 1.0
+    @test profile_value(p, (4.0, 0.0)) ≈ 0.0
+    @test profile_value(p, (0.0, 6.0)) ≈ 0.0
+    # Product of per-axis envelopes.
+    expected = cos(pi * 2.0 / (2 * 4.0))^2 * cos(pi * 3.0 / (2 * 6.0))^2
+    @test profile_value(p, (2.0, 3.0)) ≈ expected
+end
+
+@testset "profile_value: SinPowerProfile AxisProduct (N=2 ≡ SinSquare)" begin
+    p2 = SinPowerProfile{2}([4.0, 6.0])
+    pss = SinSquareProfile([4.0, 6.0])
+    for ds in [(0.0, 0.0), (1.0, 1.0), (2.0, 3.0), (3.5, 5.5)]
+        @test profile_value(p2, ds) ≈ profile_value(pss, ds)
+    end
+end
+
+@testset "profile_value: CosineRamp + AxisProduct unsupported" begin
+    p = CosineRampProfile(5.0, 1.0)
+    @test_throws ErrorException profile_value(p, (1.0, 2.0))
+end

--- a/test/base/test_modulation_nd_core.jl
+++ b/test/base/test_modulation_nd_core.jl
@@ -2,11 +2,7 @@ using ITensorModels
 using Test
 
 @testset "RadialEnvelope: type construction" begin
-    env = RadialEnvelope(
-        BoundingBoxCenter(),
-        EuclideanDistance(),
-        SinSquareProfile(3.0),
-    )
+    env = RadialEnvelope(BoundingBoxCenter(), EuclideanDistance(), SinSquareProfile(3.0))
     @test env isa RadialEnvelope
     @test env isa AbstractModulationND
     @test env isa AbstractModulation
@@ -47,7 +43,8 @@ end
     # In 2D, perpendicular distance to axis 1 is |Δr[2]|.
     @test distance_at_position(PerpendicularDistance(1), [3.0, 4.0], [0.0, 0.0]) ≈ 4.0
     # In 3D, perpendicular to axis 3 is sqrt(Δr[1]^2 + Δr[2]^2).
-    @test distance_at_position(PerpendicularDistance(3), [3.0, 4.0, 5.0], [0.0, 0.0, 0.0]) ≈ 5.0
+    @test distance_at_position(PerpendicularDistance(3), [3.0, 4.0, 5.0], [0.0, 0.0, 0.0]) ≈
+        5.0
     @test distance_at_position(PerpendicularDistance(2), [3.0, 4.0, 5.0], [0.0, 0.0, 0.0]) ≈
         sqrt(3.0^2 + 5.0^2)
 end


### PR DESCRIPTION
## Summary

First PR in the stacked **feat/modulation-2d-\\*** chain that generalises the existing 1D \ machinery (SSD / SinPower / SmoothBoundary / Tabulated) to arbitrary-dimensional lattices (honeycomb / kagome / square / triangular / ...).

This PR introduces only the lattice-free foundation: types, formulas, and lattice-independent unit tests.

* \ — new dispatch family for ND envelopes; existing 1D dispatch path is unaffected.
* Orthogonal decomposition: \ evaluating to \.
* Concrete primitives: \ / \ / \; \ / \ / \ / \; \ / \ / \.
* \ is defined as \ (not the naive \) so the bulk-plateau-vs-N semantics match the 1D \ convention.
* \ is lattice-free; \ / \ / \ / \ / \ are declared as generic stubs (methods land in PR #2 via \).
* \ captures the agreed formalism, decision log (D1-D6) and per-PR file plan for the rest of the chain.

## Test plan

- [x] \ green (192/192 passing) on \
- [x] New \ covers: every primitive constructor; every \ overload (Euclidean / Axial / Perpendicular / AxisProduct); every \ overload incl. scalar + tuple paths; \ regression; \ not-yet-supported error.
- [x] No change to existing 1D test files.

## Stacked PR plan

This is **PR #1 of 6**:

1. **#1 (this)** foundation - types, formulas, unit tests
2. #2 lattice-ext - \ / \ / \ / \ on \ + honeycomb sanity tests
3. #3 modulated-lattice - \ wrapper + \ + OpSum-on-honeycomb test
4. #4 1d-equivalence - regression that ND-on-LineLattice == 1D \
5. #5 factories - \ / \ / \ helpers
6. #6 examples - plot scripts + honeycomb envelope scatter

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>