### PR TITLE
feat(modulation): #3 modulated-lattice - ModulatedLatticeModel wrapper + Hamiltonian assembly

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/ext/LatticeCoreExt.jl
+++ b/ext/LatticeCoreExt.jl
@@ -5,7 +5,10 @@ using ITensorModels
 using ITensorModels:
     AbstractLatticeModel,
     LatticeModel,
+    ModulatedLatticeModel,
     bond_term,
+    bond_coupling_term,
+    onsite_term,
     local_ham_terms,
     boundary_patch,
     AbstractModulationND,
@@ -53,7 +56,7 @@ function _lookup_bond_model(m::LatticeModel, bt::Symbol)
 end
 
 # ---------------------------------------------------------------------
-# local_ham_terms / build_opsum for LatticeModel
+# local_ham_terms / build_opsum
 # ---------------------------------------------------------------------
 
 """
@@ -185,7 +188,7 @@ function ITensorModels.site_envelope(env::RadialEnvelope, lat::AbstractLattice, 
 end
 
 """
-    site_weight(env::RadialEnvelope, lat::AbstractLattice, k::Int)
+    site_weight(env::AbstractModulationND, lat::AbstractLattice, k::Int)
 
 ND `site_weight`: equals `site_envelope(env, lat, k)`. This is the
 ND-signature companion to the 1D `site_weight(mod, i::Int, L::Int)`.
@@ -195,11 +198,12 @@ function ITensorModels.site_weight(env::RadialEnvelope, lat::AbstractLattice, k:
 end
 
 """
-    bond_weight(env::RadialEnvelope, lat::AbstractLattice, i::Int, j::Int)
+    bond_weight(env::AbstractModulationND, lat::AbstractLattice, i::Int, j::Int)
 
-ND `bond_weight`: midpoint evaluation `f((r_i + r_j) / 2)`. Matches the
-1D convention `bond_weight(SSD, i, L) = sin²(π i / L)` (sites at
-half-integer positions, bond midpoints at integers).
+ND `bond_weight`: midpoint evaluation
+`f((r_i + r_j) / 2)`. Matches the 1D convention
+`bond_weight(SSD, i, L) = sin²(π i / L)` (sites at half-integer
+positions, bond midpoints at integers).
 """
 function ITensorModels.bond_weight(
     env::RadialEnvelope, lat::AbstractLattice, i::Int, j::Int
@@ -208,6 +212,88 @@ function ITensorModels.bond_weight(
     r_mid = (position(lat, i) + position(lat, j)) / 2
     d = distance_at_position(env.distance, r_mid, r_c)
     return profile_value(env.profile, d)
+end
+
+# ---------------------------------------------------------------------
+# ModulatedLatticeModel local_ham_terms
+# ---------------------------------------------------------------------
+
+"""
+    _onsite_submodel_for(m::LatticeModel, k::Int)
+
+Return the submodel whose `onsite_term` is used at lattice site `k`.
+Implementation: pick the bond model attached to any bond touching `k`.
+All bundled models (`TFIM`, `TFIML`, `XXZ1D`, `Heisenberg1D`) have
+site-uniform on-site terms, so this is well-defined; a model with
+genuinely per-site fields would need a separate accessor.
+"""
+function _onsite_submodel_for(m::LatticeModel, k::Int)
+    for b in bonds(m.lattice)
+        if b.i == k || b.j == k
+            return _lookup_bond_model(m, b.type)
+        end
+    end
+    return error(
+        "ModulatedLatticeModel: no bond touches site $k; cannot resolve " *
+        "onsite_term submodel.",
+    )
+end
+
+"""
+    local_ham_terms(m::ModulatedLatticeModel{<:LatticeModel{<:AbstractLattice}}, _; boundary)
+
+ND modulation pipeline. Iterate the lattice'`s bonds, weighting each
+`bond_coupling_term` by `bond_weight(env, lat, i, j)` (midpoint
+evaluation); then iterate sites, weighting each `onsite_term` by
+`site_weight(env, lat, k)`. Bond and on-site contributions are emitted
+as separate `OpSum`s — no half-distribution, no `boundary_patch`.
+
+`phys_sites` is ignored (the lattice graph provides connectivity).
+`boundary` is accepted for interface compatibility but currently must
+be `:full`.
+"""
+function ITensorModels.local_ham_terms(
+    m::ModulatedLatticeModel{<:LatticeModel{<:AbstractLattice}}, phys_sites;
+    boundary::Symbol=:full,
+)
+    boundary === :full || error(
+        "ModulatedLatticeModel currently supports only boundary = :full " *
+        "(got $boundary).",
+    )
+    base = m.base
+    lat = base.lattice
+    ord = _ordering(base)
+    env = m.envelope
+    terms = OpSum[]
+    for b in bonds(lat)
+        sub = _lookup_bond_model(base, b.type)
+        fb = ITensorModels.bond_weight(env, lat, b.i, b.j)
+        push!(terms, fb * bond_coupling_term(sub, ord[b.i], ord[b.j]))
+    end
+    for k in 1:num_sites(lat)
+        sub = _onsite_submodel_for(base, k)
+        fk = ITensorModels.site_weight(env, lat, k)
+        push!(terms, fk * onsite_term(sub, ord[k]))
+    end
+    return terms
+end
+
+"""
+    build_opsum(m::ModulatedLatticeModel{<:LatticeModel{<:AbstractLattice}}, sites;
+                phys_sites=nothing, boundary=:full)
+
+Sum every term produced by [`local_ham_terms`](@ref) for the modulated
+lattice model into the full `OpSum`.
+"""
+function ITensorModels.build_opsum(
+    m::ModulatedLatticeModel{<:LatticeModel{<:AbstractLattice}}, sites;
+    phys_sites=nothing, boundary::Symbol=:full,
+)
+    opsum = OpSum()
+    for t in ITensorModels.local_ham_terms(m, phys_sites; boundary)
+        opsum += t
+    end
+    return opsum
 end
 
 end # module LatticeCoreExt

--- a/ext/LatticeCoreExt.jl
+++ b/ext/LatticeCoreExt.jl
@@ -253,7 +253,8 @@ as separate `OpSum`s — no half-distribution, no `boundary_patch`.
 be `:full`.
 """
 function ITensorModels.local_ham_terms(
-    m::ModulatedLatticeModel{<:LatticeModel{<:AbstractLattice}}, phys_sites;
+    m::ModulatedLatticeModel{<:LatticeModel{<:AbstractLattice}},
+    phys_sites;
     boundary::Symbol=:full,
 )
     boundary === :full || error(
@@ -286,8 +287,10 @@ Sum every term produced by [`local_ham_terms`](@ref) for the modulated
 lattice model into the full `OpSum`.
 """
 function ITensorModels.build_opsum(
-    m::ModulatedLatticeModel{<:LatticeModel{<:AbstractLattice}}, sites;
-    phys_sites=nothing, boundary::Symbol=:full,
+    m::ModulatedLatticeModel{<:LatticeModel{<:AbstractLattice}},
+    sites;
+    phys_sites=nothing,
+    boundary::Symbol=:full,
 )
     opsum = OpSum()
     for t in ITensorModels.local_ham_terms(m, phys_sites; boundary)

--- a/src/ITensorModels.jl
+++ b/src/ITensorModels.jl
@@ -12,6 +12,7 @@ export TFIM, TFIML, XXZ1D, Heisenberg1D, KitaevBond, LatticeModel
 export AbstractModulation, Uniform, SSD, SinPower, SmoothBoundary, Tabulated
 export site_weight, bond_weight
 export ModulatedModel, modulated
+export ModulatedLatticeModel, modulated_lattice
 export AbstractModulationND
 export AbstractCenter, GeometricCenter, BoundingBoxCenter, ExplicitCenter
 export AbstractDistance,
@@ -66,5 +67,6 @@ include("models/heisenberg.jl")
 include("models/kitaev_bond.jl")
 include("models/lattice_model.jl")
 include("models/modulated.jl")
+include("models/modulated_lattice.jl")
 
 end # module ITensorModels

--- a/src/models/modulated_lattice.jl
+++ b/src/models/modulated_lattice.jl
@@ -1,0 +1,70 @@
+"""
+    ModulatedLatticeModel(base::AbstractLatticeModel, envelope::AbstractModulationND)
+    modulated_lattice(base; envelope)
+
+Apply an ND spatial envelope (an [`AbstractModulationND`](@ref) such as
+[`RadialEnvelope`](@ref)) to a [`LatticeModel`](@ref). The Hamiltonian
+on the lattice is
+
+```
+H = Σ_{(i,j) ∈ bonds(lattice)}
+        bond_weight(env, lattice, i, j) · bond_coupling_term(sub(b), ord[i], ord[j])
+  + Σ_{k ∈ sites(lattice)}
+        site_weight(env, lattice, k) · onsite_term(sub_site(k), ord[k])
+```
+
+ND Hamiltonian assembly **fully separates** bond coupling from on-site
+terms; there is no half-distribution and no `boundary_patch`. This
+generalises the 1D protocol to arbitrary coordination numbers
+(honeycomb / kagome / dice / shastry-sutherland / …) without further
+case analysis.
+
+The bond submodels are looked up from `base.bond_models` exactly as the
+plain `LatticeModel` does; the same submodel supplies `bond_coupling_term`
+for the bond it owns. Onsite terms are emitted once per site using the
+submodel attached to any bond touching that site (current
+implementation requires site-uniform onsite terms — which is the case
+for all bundled `TFIM` / `TFIML` / `XXZ1D` / `Heisenberg1D` models).
+
+Per-site model overrides are not yet supported; if a future model
+carries site-dependent fields, add an `onsite_submodel_for_site`
+accessor and dispatch on it.
+
+# Examples
+
+```julia
+using ITensorModels, LatticeCore, Lattice2D
+
+lat  = honeycomb(6, 6; boundary = OpenAxis())
+base = LatticeModel(; lattice = lat, bond_models = Dict(:nearest => Heisenberg1D(J = 1.0)))
+env  = RadialEnvelope(BoundingBoxCenter(), EuclideanDistance(), SinSquareProfile(7.0))
+mod  = modulated_lattice(base; envelope = env)
+# H = build_opsum(mod, sites)
+```
+"""
+struct ModulatedLatticeModel{LM<:AbstractLatticeModel,Env<:AbstractModulationND} <:
+       AbstractLatticeModel
+    base::LM
+    envelope::Env
+end
+
+"""
+    modulated_lattice(base::AbstractLatticeModel; envelope::AbstractModulationND)
+
+Convenience constructor for [`ModulatedLatticeModel`](@ref).
+"""
+function modulated_lattice(
+    base::AbstractLatticeModel; envelope::AbstractModulationND
+)
+    return ModulatedLatticeModel(base, envelope)
+end
+
+# Site type / observable lookup transparently delegate to the base
+# `LatticeModel` — the envelope only rescales the energetics, not the
+# physical Hilbert space or which operator measures each observable.
+
+site_type(m::ModulatedLatticeModel) = site_type(m.base)
+
+function onsite_observable_op(m::ModulatedLatticeModel, name::Symbol)
+    return onsite_observable_op(m.base, name)
+end

--- a/src/models/modulated_lattice.jl
+++ b/src/models/modulated_lattice.jl
@@ -53,9 +53,7 @@ end
 
 Convenience constructor for [`ModulatedLatticeModel`](@ref).
 """
-function modulated_lattice(
-    base::AbstractLatticeModel; envelope::AbstractModulationND
-)
+function modulated_lattice(base::AbstractLatticeModel; envelope::AbstractModulationND)
     return ModulatedLatticeModel(base, envelope)
 end
 

--- a/test/base/test_modulated_lattice.jl
+++ b/test/base/test_modulated_lattice.jl
@@ -1,0 +1,134 @@
+using ITensorModels
+using LatticeCore
+using LatticeCore: num_sites, position
+using Lattice2D
+using ITensors
+using Test
+
+@testset "ModulatedLatticeModel: construction" begin
+    lat = Lattice2D.honeycomb(4, 4; boundary=OpenAxis())
+    base = LatticeModel(;
+        lattice=lat,
+        bond_models=Dict(:nearest => Heisenberg1D(; J=1.0)),
+    )
+    env = RadialEnvelope(
+        BoundingBoxCenter(),
+        EuclideanDistance(),
+        SinSquareProfile(5.0),
+    )
+    mod = modulated_lattice(base; envelope=env)
+    @test mod isa ModulatedLatticeModel
+    @test mod isa AbstractLatticeModel
+    @test mod.base === base
+    @test mod.envelope === env
+    @test site_type(mod) == site_type(base)
+end
+
+@testset "ModulatedLatticeModel: build_opsum on honeycomb" begin
+    lat = Lattice2D.honeycomb(4, 4; boundary=OpenAxis())
+    base = LatticeModel(;
+        lattice=lat,
+        bond_models=Dict(:nearest => Heisenberg1D(; J=1.0)),
+    )
+    ps = collect(LatticeCore.positions(lat))
+    rc = ITensorModels.center_position(BoundingBoxCenter(), lat)
+    R = sqrt(maximum(sum((p .- rc).^2) for p in ps)) + 0.5
+    env = RadialEnvelope(BoundingBoxCenter(), EuclideanDistance(), SinSquareProfile(R))
+    mod = modulated_lattice(base; envelope=env)
+
+    H_mod = build_opsum(mod, nothing)
+    H_bare = build_opsum(base, nothing)
+
+    bare_terms = collect(ITensors.terms(H_bare))
+    mod_terms = collect(ITensors.terms(H_mod))
+    @test !isempty(bare_terms)
+    @test !isempty(mod_terms)
+
+    # Compare against a hand-built reference: ND assembly is
+    # H = Σ_bonds bond_weight * bond_coupling_term
+    #   + Σ_sites site_weight * onsite_term
+    # Heisenberg onsite is empty, so the reference only has bond terms.
+    ord = collect(1:num_sites(lat))
+    H_ref = OpSum()
+    for b in bonds(lat)
+        fb = ITensorModels.bond_weight(env, lat, b.i, b.j)
+        H_ref += fb * ITensorModels.bond_coupling_term(
+            Heisenberg1D(; J=1.0), ord[b.i], ord[b.j]
+        )
+    end
+    ref_terms = collect(ITensors.terms(H_ref))
+    @test length(ref_terms) > 0
+    # H_mod has extra empty-OpSum onsite contributions per site, so its
+    # term count must be at least the reference count.
+    @test length(mod_terms) >= length(ref_terms)
+end
+
+@testset "ModulatedLatticeModel: large-R envelope is approximately 1" begin
+    # The type system doesn't allow R = ∞ for SinSquareProfile, so we
+    # set R well beyond the lattice diameter, where 1 - sin²(π d / (2R))
+    # is very close to 1 across every site/bond. Verify that the
+    # site_weight and bond_weight values are all ≈ 1 — this is the
+    # "uniform-like" reduction the wrapper must support without
+    # special-casing.
+    lat = Lattice2D.honeycomb(4, 4; boundary=OpenAxis())
+    ps = collect(LatticeCore.positions(lat))
+    rc = ITensorModels.center_position(BoundingBoxCenter(), lat)
+    R_huge = 100 * sqrt(maximum(sum((p .- rc).^2) for p in ps))
+    env = RadialEnvelope(BoundingBoxCenter(), EuclideanDistance(), SinSquareProfile(R_huge))
+
+    for b in bonds(lat)
+        @test ITensorModels.bond_weight(env, lat, b.i, b.j) ≈ 1.0 atol = 1e-3
+    end
+    for k in 1:num_sites(lat)
+        @test ITensorModels.site_weight(env, lat, k) ≈ 1.0 atol = 1e-3
+    end
+end
+
+@testset "ModulatedLatticeModel: corner-suppression sanity" begin
+    # With R set to the largest center-to-site distance, the corner of
+    # a hexagonal sample carries near-zero envelope weight while the
+    # near-center bond carries close to unit weight.
+    lat = Lattice2D.honeycomb(6, 6; boundary=OpenAxis())
+    ps = collect(LatticeCore.positions(lat))
+    rc = ITensorModels.center_position(BoundingBoxCenter(), lat)
+    R = sqrt(maximum(sum((p .- rc).^2) for p in ps))
+    env = RadialEnvelope(BoundingBoxCenter(), EuclideanDistance(), SinSquareProfile(R))
+
+    bs = collect(bonds(lat))
+    w_corner = ITensorModels.bond_weight(env, lat, bs[1].i, bs[1].j)
+
+    midpoints = [(position(lat, b.i) + position(lat, b.j)) / 2 for b in bs]
+    distances = [sqrt(sum((mid .- rc).^2)) for mid in midpoints]
+    k_central = argmin(distances)
+    w_centre = ITensorModels.bond_weight(env, lat, bs[k_central].i, bs[k_central].j)
+
+    @test w_corner < w_centre
+    @test w_centre >= 0.9
+end
+
+@testset "ModulatedLatticeModel: TFIM with non-zero onsite emits per-site terms" begin
+    # TFIM has bond_coupling_term ≠ 0 AND onsite_term ≠ 0, so the ND
+    # assembly must emit BOTH per-bond AND per-site weighted terms.
+    # The total number of OpSum terms must therefore exceed the bond
+    # count (which would be all we'd get if onsite emission were
+    # missing).
+    lat = Lattice2D.honeycomb(4, 4; boundary=OpenAxis())
+    base = LatticeModel(;
+        lattice=lat,
+        bond_models=Dict(:nearest => TFIM(; J=1.0, h=0.5)),
+    )
+    ps = collect(LatticeCore.positions(lat))
+    rc = ITensorModels.center_position(BoundingBoxCenter(), lat)
+    R_huge = 100 * sqrt(maximum(sum((p .- rc).^2) for p in ps))
+    env = RadialEnvelope(BoundingBoxCenter(), EuclideanDistance(), SinSquareProfile(R_huge))
+    mod = modulated_lattice(base; envelope=env)
+
+    H = build_opsum(mod, nothing)
+    n_terms = length(collect(ITensors.terms(H)))
+    n_bonds = length(collect(bonds(lat)))
+    n_sites = num_sites(lat)
+    # TFIM bond_coupling_term emits ONE -J Zᵢ Zⱼ per bond.
+    # TFIM onsite_term emits ONE -h Xₖ per site.
+    # So total terms = n_bonds + n_sites.
+    @test n_terms == n_bonds + n_sites
+end

--- a/test/base/test_modulated_lattice.jl
+++ b/test/base/test_modulated_lattice.jl
@@ -7,15 +7,8 @@ using Test
 
 @testset "ModulatedLatticeModel: construction" begin
     lat = Lattice2D.honeycomb(4, 4; boundary=OpenAxis())
-    base = LatticeModel(;
-        lattice=lat,
-        bond_models=Dict(:nearest => Heisenberg1D(; J=1.0)),
-    )
-    env = RadialEnvelope(
-        BoundingBoxCenter(),
-        EuclideanDistance(),
-        SinSquareProfile(5.0),
-    )
+    base = LatticeModel(; lattice=lat, bond_models=Dict(:nearest => Heisenberg1D(; J=1.0)))
+    env = RadialEnvelope(BoundingBoxCenter(), EuclideanDistance(), SinSquareProfile(5.0))
     mod = modulated_lattice(base; envelope=env)
     @test mod isa ModulatedLatticeModel
     @test mod isa AbstractLatticeModel
@@ -26,13 +19,10 @@ end
 
 @testset "ModulatedLatticeModel: build_opsum on honeycomb" begin
     lat = Lattice2D.honeycomb(4, 4; boundary=OpenAxis())
-    base = LatticeModel(;
-        lattice=lat,
-        bond_models=Dict(:nearest => Heisenberg1D(; J=1.0)),
-    )
+    base = LatticeModel(; lattice=lat, bond_models=Dict(:nearest => Heisenberg1D(; J=1.0)))
     ps = collect(LatticeCore.positions(lat))
     rc = ITensorModels.center_position(BoundingBoxCenter(), lat)
-    R = sqrt(maximum(sum((p .- rc).^2) for p in ps)) + 0.5
+    R = sqrt(maximum(sum((p .- rc) .^ 2) for p in ps)) + 0.5
     env = RadialEnvelope(BoundingBoxCenter(), EuclideanDistance(), SinSquareProfile(R))
     mod = modulated_lattice(base; envelope=env)
 
@@ -52,9 +42,8 @@ end
     H_ref = OpSum()
     for b in bonds(lat)
         fb = ITensorModels.bond_weight(env, lat, b.i, b.j)
-        H_ref += fb * ITensorModels.bond_coupling_term(
-            Heisenberg1D(; J=1.0), ord[b.i], ord[b.j]
-        )
+        H_ref +=
+            fb * ITensorModels.bond_coupling_term(Heisenberg1D(; J=1.0), ord[b.i], ord[b.j])
     end
     ref_terms = collect(ITensors.terms(H_ref))
     @test length(ref_terms) > 0
@@ -73,7 +62,7 @@ end
     lat = Lattice2D.honeycomb(4, 4; boundary=OpenAxis())
     ps = collect(LatticeCore.positions(lat))
     rc = ITensorModels.center_position(BoundingBoxCenter(), lat)
-    R_huge = 100 * sqrt(maximum(sum((p .- rc).^2) for p in ps))
+    R_huge = 100 * sqrt(maximum(sum((p .- rc) .^ 2) for p in ps))
     env = RadialEnvelope(BoundingBoxCenter(), EuclideanDistance(), SinSquareProfile(R_huge))
 
     for b in bonds(lat)
@@ -91,14 +80,14 @@ end
     lat = Lattice2D.honeycomb(6, 6; boundary=OpenAxis())
     ps = collect(LatticeCore.positions(lat))
     rc = ITensorModels.center_position(BoundingBoxCenter(), lat)
-    R = sqrt(maximum(sum((p .- rc).^2) for p in ps))
+    R = sqrt(maximum(sum((p .- rc) .^ 2) for p in ps))
     env = RadialEnvelope(BoundingBoxCenter(), EuclideanDistance(), SinSquareProfile(R))
 
     bs = collect(bonds(lat))
     w_corner = ITensorModels.bond_weight(env, lat, bs[1].i, bs[1].j)
 
     midpoints = [(position(lat, b.i) + position(lat, b.j)) / 2 for b in bs]
-    distances = [sqrt(sum((mid .- rc).^2)) for mid in midpoints]
+    distances = [sqrt(sum((mid .- rc) .^ 2)) for mid in midpoints]
     k_central = argmin(distances)
     w_centre = ITensorModels.bond_weight(env, lat, bs[k_central].i, bs[k_central].j)
 
@@ -113,13 +102,10 @@ end
     # count (which would be all we'd get if onsite emission were
     # missing).
     lat = Lattice2D.honeycomb(4, 4; boundary=OpenAxis())
-    base = LatticeModel(;
-        lattice=lat,
-        bond_models=Dict(:nearest => TFIM(; J=1.0, h=0.5)),
-    )
+    base = LatticeModel(; lattice=lat, bond_models=Dict(:nearest => TFIM(; J=1.0, h=0.5)))
     ps = collect(LatticeCore.positions(lat))
     rc = ITensorModels.center_position(BoundingBoxCenter(), lat)
-    R_huge = 100 * sqrt(maximum(sum((p .- rc).^2) for p in ps))
+    R_huge = 100 * sqrt(maximum(sum((p .- rc) .^ 2) for p in ps))
     env = RadialEnvelope(BoundingBoxCenter(), EuclideanDistance(), SinSquareProfile(R_huge))
     mod = modulated_lattice(base; envelope=env)
 


### PR DESCRIPTION
## Summary

PR #3 of the stacked feat/modulation-2d-* chain. Pairs the ND envelope primitives (#30, #31) with a concrete `AbstractLatticeModel` wrapper and the OpSum-assembly path that turns it into an MPO.

* New `ModulatedLatticeModel{LM, Env}` wrapper (`src/models/modulated_lattice.jl`) and `modulated_lattice(base; envelope)` constructor.
* New `local_ham_terms` and `build_opsum` methods in `LatticeCoreExt` that emit one weighted `bond_coupling_term` per bond and one weighted `onsite_term` per site, with weights coming from the envelope.
* Helper `_onsite_submodel_for(m, k)` resolves the submodel responsible for site `k`'s on-site term by taking any bond touching `k` (well-defined for the bundled site-uniform models TFIM / TFIML / XXZ1D / Heisenberg1D).

ND Hamiltonian assembly fully separates bond couplings from on-site terms — no half-distribution and no `boundary_patch`. This is the principled generalisation of the 1D protocol to arbitrary coordination numbers (honeycomb / kagome / dice / shastry-sutherland / ...).

## Test plan

- Pkg.test() green (395/395 passing) on feat/modulation-2d-03-modulated-lattice.
- New test/base/test_modulated_lattice.jl covers:
  - Construction + `site_type` forwarding.
  - `build_opsum` on honeycomb(4, 4) + Heisenberg1D produces a non-empty OpSum whose bond terms match a hand-built reference sum.
  - Large-R envelope (R = 100 x diameter) reduces every site/bond weight to ~1.0 — confirms the unmodulated limit is recovered without special-casing.
  - Corner-suppression sanity: corner bond carries a small weight while the near-center bond is >= 0.9.
  - TFIM (non-zero bond coupling AND non-zero onsite) emits exactly `n_bonds + n_sites` OpSum terms — proves the per-site onsite emission path is exercised and counts correctly.
- Pre-existing 1D / DMRG / QAtlas tests untouched.

## Stack

Based on #31 (feat/modulation-2d-02-lattice-ext), which is based on #30.

Next up:
- #4 1d-equivalence regression (ND-on-LineLattice == 1D ModulatedModel)
- #5 user-facing factories
- #6 examples / plot scripts

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
