### PR TITLE
feat(modulation): #5 factories - spherical_ssd / cylindrical_ssd / rectangular_ssd

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.6.3"
+version = "0.6.4"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/ext/LatticeCoreExt.jl
+++ b/ext/LatticeCoreExt.jl
@@ -299,4 +299,79 @@ function ITensorModels.build_opsum(
     return opsum
 end
 
+# ---------------------------------------------------------------------
+# User-facing factories
+# ---------------------------------------------------------------------
+
+"""
+    _bounding_extent(lat::AbstractLattice) -> (lo, hi)
+
+Per-axis bounding box of all site positions in `lat`. Internal helper
+used by the ND factories.
+"""
+function _bounding_extent(lat::AbstractLattice)
+    N = num_sites(lat)
+    N >= 1 || error("_bounding_extent: lattice has zero sites")
+    lo = position(lat, 1)
+    hi = lo
+    for k in 2:N
+        p = position(lat, k)
+        lo = min.(lo, p)
+        hi = max.(hi, p)
+    end
+    return lo, hi
+end
+
+"""
+    _make_profile(::Val{2}, R) -> SinSquareProfile(R)
+    _make_profile(::Val{N}, R) -> SinPowerProfile{N}(R)
+
+Pick the right profile constructor for a given power `N`. At `N = 2`
+the canonical SSD profile is used (slightly faster than the equivalent
+`SinPowerProfile{2}`).
+"""
+_make_profile(::Val{2}, R) = SinSquareProfile(R)
+_make_profile(::Val{N}, R) where {N} = SinPowerProfile{N}(R)
+
+function ITensorModels.spherical_ssd(
+    lat::AbstractLattice; radius::Symbol=:inscribed, N::Int=2
+)
+    lo, hi = _bounding_extent(lat)
+    half = (hi - lo) / 2
+    R = if radius === :inscribed
+        minimum(half)
+    elseif radius === :circumscribed
+        sqrt(sum(half .^ 2))
+    else
+        error(
+            "spherical_ssd: radius must be :inscribed or :circumscribed " *
+            "(got :$radius)",
+        )
+    end
+    return RadialEnvelope(
+        BoundingBoxCenter(), EuclideanDistance(), _make_profile(Val(N), R)
+    )
+end
+
+function ITensorModels.cylindrical_ssd(
+    lat::AbstractLattice; axis::Int=1, N::Int=2
+)
+    lo, hi = _bounding_extent(lat)
+    1 <= axis <= length(lo) || error(
+        "cylindrical_ssd: axis=$axis out of range [1, $(length(lo))]"
+    )
+    R = (hi[axis] - lo[axis]) / 2
+    return RadialEnvelope(
+        BoundingBoxCenter(), AxialDistance(axis), _make_profile(Val(N), R)
+    )
+end
+
+function ITensorModels.rectangular_ssd(lat::AbstractLattice; N::Int=2)
+    lo, hi = _bounding_extent(lat)
+    half = (hi - lo) / 2
+    return RadialEnvelope(
+        BoundingBoxCenter(), AxisProductDistance(), _make_profile(Val(N), half)
+    )
+end
+
 end # module LatticeCoreExt

--- a/src/ITensorModels.jl
+++ b/src/ITensorModels.jl
@@ -20,6 +20,7 @@ export AbstractDistance,
 export AbstractProfile, SinSquareProfile, SinPowerProfile, CosineRampProfile
 export RadialEnvelope
 export distance_at_position, distance_at, center_position, profile_value, site_envelope
+export spherical_ssd, cylindrical_ssd, rectangular_ssd
 export to_qatlas, from_qatlas
 
 """
@@ -59,6 +60,7 @@ include("core/interface.jl")
 include("core/observables.jl")
 include("core/modulation.jl")
 include("core/modulation_nd.jl")
+include("core/factories_nd.jl")
 
 include("models/tfim.jl")
 include("models/tfiml.jl")

--- a/src/core/factories_nd.jl
+++ b/src/core/factories_nd.jl
@@ -1,0 +1,42 @@
+# User-facing factories for common ND envelopes. The generic
+# declarations live here; concrete methods that read the lattice
+# geometry are implemented in `ext/LatticeCoreExt.jl`.
+
+"""
+    spherical_ssd(lat; radius=:inscribed, N=2) -> RadialEnvelope
+
+Spherical SSD envelope on `lat`: BoundingBoxCenter + EuclideanDistance
++ SinPowerProfile{N}(R). `radius` selects the envelope radius from the
+lattice's bounding box:
+
+* `:inscribed` — `R = minimum_d (extent_d / 2)`. The envelope reaches
+  zero on the inscribed disk; corners are clipped to zero.
+* `:circumscribed` — `R = ‖extent / 2‖₂`. The envelope only reaches
+  zero at the corners (the extreme points); edge midpoints carry a
+  finite weight.
+
+`N = 2` returns a [`SinSquareProfile`](@ref); `N > 2` widens the bulk
+plateau (the radial Hotta–Shibata sin^N profile).
+"""
+function spherical_ssd end
+
+"""
+    cylindrical_ssd(lat; axis=1, N=2) -> RadialEnvelope
+
+Cylindrical SSD envelope on `lat`: BoundingBoxCenter +
+AxialDistance(axis) + SinPowerProfile{N}(R), where `R = extent[axis] / 2`.
+The envelope is uniform in every direction other than `axis` — natural
+for cylinders that are periodic in the perpendicular direction(s) and
+SSD-modulated along `axis`.
+"""
+function cylindrical_ssd end
+
+"""
+    rectangular_ssd(lat; N=2) -> RadialEnvelope
+
+Rectangular (axis-product) SSD envelope on `lat`: BoundingBoxCenter +
+AxisProductDistance + SinPowerProfile{N}(SVector(R_1, …, R_D)), with
+`R_d = extent_d / 2`. Equivalent to the LatticeCore hypercubic SSD
+`∏_d sin²(π (c_d − 1/2) / L_d)`.
+"""
+function rectangular_ssd end

--- a/test/base/test_modulation_nd_factories.jl
+++ b/test/base/test_modulation_nd_factories.jl
@@ -1,0 +1,119 @@
+using ITensorModels
+using LatticeCore
+using LatticeCore: num_sites, position
+using Lattice2D
+using Test
+
+@testset "spherical_ssd: inscribed envelope vanishes at far corner" begin
+    lat = Lattice2D.honeycomb(6, 6; boundary=OpenAxis())
+    env_in = spherical_ssd(lat; radius=:inscribed)
+    @test env_in isa RadialEnvelope
+    @test env_in.center isa BoundingBoxCenter
+    @test env_in.distance isa EuclideanDistance
+    @test env_in.profile isa SinSquareProfile
+    # The site at the maximum-distance corner lies outside the inscribed
+    # disk (its Euclidean distance to the center exceeds min(extent_d) / 2);
+    # site_weight clips to 0 there.
+    ps = collect(LatticeCore.positions(lat))
+    rc = ITensorModels.center_position(BoundingBoxCenter(), lat)
+    k_corner = argmax([sqrt(sum((p .- rc).^2)) for p in ps])
+    @test ITensorModels.site_weight(env_in, lat, k_corner) ≈ 0.0 atol = 1e-12
+end
+
+@testset "spherical_ssd: circumscribed envelope is non-zero except at far corner" begin
+    lat = Lattice2D.honeycomb(6, 6; boundary=OpenAxis())
+    env_out = spherical_ssd(lat; radius=:circumscribed)
+    @test env_out isa RadialEnvelope
+    @test env_out.profile isa SinSquareProfile
+    ps = collect(LatticeCore.positions(lat))
+    rc = ITensorModels.center_position(BoundingBoxCenter(), lat)
+    distances = [sqrt(sum((p .- rc).^2)) for p in ps]
+    d_max = maximum(distances)
+    for k in 1:num_sites(lat)
+        w = ITensorModels.site_weight(env_out, lat, k)
+        if isapprox(distances[k], d_max; atol=1e-12)
+            @test w ≈ 0.0 atol = 1e-12
+        else
+            @test w > 0.0
+        end
+    end
+end
+
+@testset "spherical_ssd: N controls plateau width" begin
+    lat = Lattice2D.honeycomb(6, 6; boundary=OpenAxis())
+    env_n2 = spherical_ssd(lat; radius=:circumscribed, N=2)
+    env_n4 = spherical_ssd(lat; radius=:circumscribed, N=4)
+    @test env_n2.profile isa SinSquareProfile
+    @test env_n4.profile isa SinPowerProfile{4}
+    # SinPower{4} has a wider plateau than SinSquare on (0, R), so the
+    # weight at any non-boundary distance must satisfy w_n4 >= w_n2.
+    for k in 1:num_sites(lat)
+        w2 = ITensorModels.site_weight(env_n2, lat, k)
+        w4 = ITensorModels.site_weight(env_n4, lat, k)
+        @test w4 >= w2 - 1e-12
+    end
+end
+
+@testset "spherical_ssd: radius keyword validation" begin
+    lat = Lattice2D.honeycomb(4, 4; boundary=OpenAxis())
+    @test_throws ErrorException spherical_ssd(lat; radius=:bogus)
+end
+
+@testset "cylindrical_ssd: uniform perpendicular to axis" begin
+    lat = Lattice2D.honeycomb(6, 6; boundary=OpenAxis())
+    env = cylindrical_ssd(lat; axis=1)
+    @test env isa RadialEnvelope
+    @test env.distance isa AxialDistance
+    @test env.distance.axis == 1
+
+    ps = collect(LatticeCore.positions(lat))
+    by_x = Dict{Float64,Vector{Int}}()
+    for k in 1:num_sites(lat)
+        x = ps[k][1]
+        push!(get!(by_x, x, Int[]), k)
+    end
+    same_x_groups = [v for v in values(by_x) if length(v) > 1]
+    @test !isempty(same_x_groups)
+    for group in same_x_groups
+        ws = [ITensorModels.site_weight(env, lat, k) for k in group]
+        @test all(w -> w ≈ ws[1], ws)
+    end
+end
+
+@testset "cylindrical_ssd: axis validation" begin
+    lat = Lattice2D.honeycomb(4, 4; boundary=OpenAxis())   # 2D lattice
+    @test_throws ErrorException cylindrical_ssd(lat; axis=3)
+    @test_throws ErrorException cylindrical_ssd(lat; axis=0)
+end
+
+@testset "rectangular_ssd: axis-product structure" begin
+    lat = Lattice2D.honeycomb(6, 6; boundary=OpenAxis())
+    env = rectangular_ssd(lat)
+    @test env isa RadialEnvelope
+    @test env.distance isa AxisProductDistance
+    @test env.profile isa SinSquareProfile
+    # The profile carries an indexable per-axis radius.
+    @test length(env.profile.R) == 2
+
+    ps = collect(LatticeCore.positions(lat))
+    rc = ITensorModels.center_position(BoundingBoxCenter(), lat)
+    k_central = argmin([sqrt(sum((p .- rc).^2)) for p in ps])
+    @test 0.0 <= ITensorModels.site_weight(env, lat, k_central) <= 1.0
+    @test ITensorModels.site_weight(env, lat, k_central) >= 0.85
+end
+
+@testset "rectangular_ssd: matches direct RadialEnvelope construction" begin
+    lat = Lattice2D.honeycomb(4, 4; boundary=OpenAxis())
+    env_factory = rectangular_ssd(lat)
+    ps = collect(LatticeCore.positions(lat))
+    lo_axes = reduce((a, b) -> min.(a, b), ps)
+    hi_axes = reduce((a, b) -> max.(a, b), ps)
+    half = (hi_axes - lo_axes) / 2
+    env_direct = RadialEnvelope(
+        BoundingBoxCenter(), AxisProductDistance(), SinSquareProfile(half)
+    )
+    for k in 1:num_sites(lat)
+        @test ITensorModels.site_weight(env_factory, lat, k) ≈
+            ITensorModels.site_weight(env_direct, lat, k)
+    end
+end


### PR DESCRIPTION
## Summary

PR #5 of the stacked feat/modulation-2d-* chain. Adds user-facing one-call factories that wrap the verbose `RadialEnvelope(BoundingBoxCenter(), distance, profile)` form using lattice-derived radii.

* `spherical_ssd(lat; radius=:inscribed | :circumscribed, N=2)` — sphere-shaped envelope. `:inscribed` clips at the inscribed disk (corners hard-zero); `:circumscribed` only zeroes at the farthest corner.
* `cylindrical_ssd(lat; axis=1, N=2)` — single-axis SSD; uniform in every other direction. Natural for cylinders periodic in the perpendicular direction(s).
* `rectangular_ssd(lat; N=2)` — axis-product envelope; equivalent to the LatticeCore hypercubic SSD `prod_d sin^2(pi (c_d - 1/2) / L_d)`.

The `N` keyword switches between `SinSquareProfile` (N=2) and `SinPowerProfile{N>=3}` — the former is preferred at N=2 to keep the canonical SSD type intact.

Generic function declarations live in `src/core/factories_nd.jl` (lattice-free, no LatticeCore dependency); the lattice-aware methods live in `ext/LatticeCoreExt.jl` together with shared `_bounding_extent` / `_make_profile` helpers.

## Test plan

- Pkg.test() green (639/639 passing).
- New test/base/test_modulation_nd_factories.jl covers:
  - spherical_ssd :inscribed clips the far-corner to zero; :circumscribed only zeroes the far corner.
  - spherical_ssd N controls plateau width (w_N=4 >= w_N=2 everywhere).
  - spherical_ssd invalid :bogus radius raises.
  - cylindrical_ssd: uniform perpendicular to axis; out-of-range axis raises.
  - rectangular_ssd: profile carries per-axis radii; matches hand-built RadialEnvelope on every site.
- Pre-existing tests untouched.

## Stack

Based on #33 (feat/modulation-2d-04-1d-equivalence).

Next: #6 examples / plot scripts.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
