### PR TITLE
docs(modulation): #6 examples - plot scripts and honeycomb scatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 docs/build/
 Manifest.toml
 notes/
+examples/out/

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.6.4"
+version = "0.6.5"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,0 +1,8 @@
+[deps]
+ITensorModels = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
+Lattice2D = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
+LatticeCore = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+
+[sources]
+ITensorModels = {path = ".."}

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,33 @@
+# Modulation envelope examples
+
+Standalone scripts that visualise the modulation envelopes provided by
+`ITensorModels`. Each script writes its output PNGs to `examples/out/`.
+
+## Setup
+
+```bash
+cd examples
+julia --project=. -e 'using Pkg; Pkg.instantiate()'
+```
+
+The `Project.toml` here `develop`s the parent `ITensorModels` checkout
+so script changes are picked up immediately.
+
+## Scripts
+
+| Script | Visualises |
+|--------|------------|
+| `plot_modulation_1d.jl` | 1D `AbstractModulation` envelopes (`SSD`, `SinPower{N}`, `SmoothBoundary`) — `site_weight` and `bond_weight` on a length-60 chain. |
+| `plot_modulation_2d_continuous.jl` | 2D `RadialEnvelope` factory output evaluated on a continuous grid (heatmaps): rectangular / cylindrical / spherical / sin-power / smooth-ramp. |
+| `plot_modulation_honeycomb_scatter.jl` | The same envelopes sampled on a real `honeycomb(L, L)` lattice with `OpenAxis()` — scatter plot coloured by `site_weight`. |
+
+## Running
+
+```bash
+julia --project=. plot_modulation_1d.jl
+julia --project=. plot_modulation_2d_continuous.jl
+julia --project=. plot_modulation_honeycomb_scatter.jl
+```
+
+All scripts run headless (no display required) and write PNGs into
+`out/` next to the script.

--- a/examples/plot_modulation_1d.jl
+++ b/examples/plot_modulation_1d.jl
@@ -1,0 +1,60 @@
+# 1D modulation envelopes — visual sanity check of site_weight / bond_weight.
+# Output: out/*.png next to this script.
+using ITensorModels
+using Plots
+
+const L = 60
+
+modulations = [
+    ("Uniform",         Uniform()),
+    ("SSD",             SSD()),
+    ("SinPower{4}",     SinPower{4}()),
+    ("SinPower{6}",     SinPower{6}()),
+    ("SinPower{8}",     SinPower{8}()),
+    ("SmoothBoundary(5)",  SmoothBoundary(5)),
+    ("SmoothBoundary(10)", SmoothBoundary(10)),
+    ("SmoothBoundary(20)", SmoothBoundary(20)),
+]
+
+site_x = 1:L
+bond_x = 1:(L-1)
+
+# ---- site_weight ----
+p_site = plot(;
+    xlabel = "site index i",
+    ylabel = "site_weight(mod, i, L=$L)",
+    title  = "site weight envelopes (1D, L=$L)",
+    legend = :outerright,
+    size   = (900, 420),
+    framestyle = :box,
+    grid = true,
+)
+for (name, m) in modulations
+    ys = [site_weight(m, i, L) for i in site_x]
+    plot!(p_site, site_x, ys; label = name, lw = 2)
+end
+
+# ---- bond_weight ----
+p_bond = plot(;
+    xlabel = "bond index i (bond connects i and i+1)",
+    ylabel = "bond_weight(mod, i, L=$L)",
+    title  = "bond weight envelopes (1D, L=$L)",
+    legend = :outerright,
+    size   = (900, 420),
+    framestyle = :box,
+    grid = true,
+)
+for (name, m) in modulations
+    ys = [bond_weight(m, i, L) for i in bond_x]
+    plot!(p_bond, bond_x, ys; label = name, lw = 2)
+end
+
+# Combined panel.
+p_all = plot(p_site, p_bond; layout = (2, 1), size = (1000, 800))
+
+outdir = joinpath(@__DIR__, "out")
+mkpath(outdir)
+savefig(p_site, joinpath(outdir, "site_weight.png"))
+savefig(p_bond, joinpath(outdir, "bond_weight.png"))
+savefig(p_all,  joinpath(outdir, "combined.png"))
+println("Wrote: ", readdir(outdir))

--- a/examples/plot_modulation_2d_continuous.jl
+++ b/examples/plot_modulation_2d_continuous.jl
@@ -1,0 +1,146 @@
+# 2D RadialEnvelope shapes — continuous-function heatmaps.
+# Visualises (rectangular | cylindrical | spherical) × (SinSquare | SinPower{N} | SmoothBoundary)
+# before committing the design to src/. No ITensorModels dependency yet
+# (the envelope formulas are inlined here precisely so we can iterate on
+# the geometry independently of the type machinery).
+using Plots
+
+const Lx = 60
+const Ly = 60
+
+# Center at the geometric midpoint of a chain of length L (matches the
+# 1D convention site_weight(SSD, i, L) = sin²(π (i - 1/2) / L), whose
+# zeros sit at i = 0 and i = L, so the center is L/2 + 0.5 in continuous
+# coordinates running over [0.5, L+0.5]).
+center(L) = (L + 1) / 2
+
+# 1-axis SSD envelope, continuous version (matches site_weight at integer i).
+ssd_axis(x, L) = sin(pi * (x - 0.5) / L)^2
+
+# 1-axis SinPower{N} envelope: cos^N(π d / (2R)).
+sin_power_axis(x, L, N) = sin(pi * (x - 0.5) / L)^N
+
+# Radial profile (1D, distance-based). Returns 1 at d=0 and 0 at d=R.
+function profile_sin_square(d, R)
+    d >= R && return 0.0
+    return cos(pi * d / (2R))^2
+end
+
+function profile_sin_power(d, R, N)
+    d >= R && return 0.0
+    return cos(pi * d / (2R))^N
+end
+
+# Smooth-boundary profile: 1 for d <= R - edge, half-cosine ramp from
+# R - edge to R (drops to 0 at d = R).
+function profile_smooth(d, R, edge)
+    d >= R && return 0.0
+    d <= R - edge && return 1.0
+    return (1 - cos(pi * (R - d) / edge)) / 2
+end
+
+# ---- Envelope realisations (D=2) ------------------------------------
+
+# (1) Rectangular SSD = axis product (≡ LatticeCore feat/ssd-weight).
+env_rect(x, y) = ssd_axis(x, Lx) * ssd_axis(y, Ly)
+
+# (2) Cylindrical SSD: SSD along the x-axis, uniform along y. (Useful
+# when y is the periodic / "compact" direction of a cylinder.)
+env_cyl_x(x, y) = ssd_axis(x, Lx)
+
+# (3) Spherical SSD with the inscribed circle R = min(Lx, Ly) / 2:
+# the envelope reaches 0 on the inscribed circle and is identically
+# zero outside it (corners are dark).
+function env_sphere_inscribed(x, y)
+    cx = center(Lx); cy = center(Ly)
+    d = sqrt((x - cx)^2 + (y - cy)^2)
+    R = min(Lx, Ly) / 2
+    profile_sin_square(d, R)
+end
+
+# (4) Spherical SSD with the circumscribed circle R = √((Lx/2)² + (Ly/2)²):
+# the envelope only reaches 0 at the corners; the four edge midpoints
+# carry a finite weight. This is what "spherical, no zero rim" looks like.
+function env_sphere_circumscribed(x, y)
+    cx = center(Lx); cy = center(Ly)
+    d = sqrt((x - cx)^2 + (y - cy)^2)
+    R = sqrt((Lx / 2)^2 + (Ly / 2)^2)
+    profile_sin_square(d, R)
+end
+
+# (5) Spherical SinPower{4}: sharper roll-off at the boundary, broader
+# central plateau (Hotta-Shibata flavour on a disk).
+function env_sphere_sinpow4(x, y)
+    cx = center(Lx); cy = center(Ly)
+    d = sqrt((x - cx)^2 + (y - cy)^2)
+    R = min(Lx, Ly) / 2
+    profile_sin_power(d, R, 4)
+end
+
+# (6) Spherical SmoothBoundary: flat-1 plateau in the bulk + half-cosine
+# ramp on the rim (Vekic-White on a disk).
+function env_sphere_smooth(x, y)
+    cx = center(Lx); cy = center(Ly)
+    d = sqrt((x - cx)^2 + (y - cy)^2)
+    R = min(Lx, Ly) / 2
+    profile_smooth(d, R, 8)
+end
+
+# ---- Build heatmaps -------------------------------------------------
+
+xs = range(0.5, Lx + 0.5; length = 200)
+ys = range(0.5, Ly + 0.5; length = 200)
+
+panels = [
+    ("Rectangular SSD\n(axis product)",                env_rect),
+    ("Cylindrical SSD (x-axial)\nuniform in y",         env_cyl_x),
+    ("Spherical SSD\ninscribed R = min(Lx,Ly)/2",       env_sphere_inscribed),
+    ("Spherical SSD\ncircumscribed R = ‖(Lx,Ly)‖/2",    env_sphere_circumscribed),
+    ("Spherical SinPower{4}\nR = min/2",                env_sphere_sinpow4),
+    ("Spherical SmoothBoundary\nR = min/2, edge = 8",   env_sphere_smooth),
+]
+
+plts = []
+for (title, f) in panels
+    Z = [f(x, y) for y in ys, x in xs]   # Z[j, i] = f(xs[i], ys[j])
+    p = heatmap(xs, ys, Z;
+        title  = title,
+        xlabel = "x",
+        ylabel = "y",
+        aspect_ratio = :equal,
+        c = :viridis,
+        clims  = (0.0, 1.0),
+        colorbar = false,
+        framestyle = :box,
+    )
+    # Overlay a 0.5-level contour to make the falloff region visible.
+    contour!(p, xs, ys, Z; levels = [0.5], lc = :white, lw = 1.2)
+    push!(plts, p)
+end
+
+p_all = plot(plts...; layout = (3, 2), size = (1100, 1500), plot_title = "2D Modulation Envelopes (Lx=Ly=$Lx)")
+
+outdir = joinpath(@__DIR__, "out")
+mkpath(outdir)
+savefig(p_all, joinpath(outdir, "2d_continuous.png"))
+println("Wrote: ", joinpath("out", "2d_continuous.png"))
+
+# Also dump a 1D radial cut through the disk envelopes so we can compare
+# the radial profiles directly.
+rs = range(0.0, min(Lx, Ly) / 2; length = 200)
+p_radial = plot(;
+    xlabel = "distance from center r",
+    ylabel = "envelope(r)",
+    title  = "Radial profile cuts (R = min(Lx,Ly)/2 = $(min(Lx,Ly) ÷ 2))",
+    legend = :outerright,
+    framestyle = :box,
+    size   = (900, 420),
+)
+plot!(p_radial, rs, [profile_sin_square(r, min(Lx, Ly) / 2) for r in rs]; label = "SinSquare", lw = 2)
+plot!(p_radial, rs, [profile_sin_power(r, min(Lx, Ly) / 2, 4) for r in rs]; label = "SinPower{4}", lw = 2)
+plot!(p_radial, rs, [profile_sin_power(r, min(Lx, Ly) / 2, 8) for r in rs]; label = "SinPower{8}", lw = 2)
+plot!(p_radial, rs, [profile_smooth(r, min(Lx, Ly) / 2, 4) for r in rs]; label = "SmoothBoundary edge=4", lw = 2)
+plot!(p_radial, rs, [profile_smooth(r, min(Lx, Ly) / 2, 8) for r in rs]; label = "SmoothBoundary edge=8", lw = 2)
+plot!(p_radial, rs, [profile_smooth(r, min(Lx, Ly) / 2, 12) for r in rs]; label = "SmoothBoundary edge=12", lw = 2)
+savefig(p_radial, joinpath(outdir, "2d_radial_profile.png"))
+println("Wrote: ", joinpath("out", "2d_radial_profile.png"))

--- a/examples/plot_modulation_honeycomb_scatter.jl
+++ b/examples/plot_modulation_honeycomb_scatter.jl
@@ -1,0 +1,58 @@
+# Honeycomb modulation envelope scatter.
+#
+# Sample each ND envelope (sphere / cylinder / rectangle, plus a
+# higher-N sphere) on a real honeycomb(L, L) lattice and scatter the
+# sites coloured by site_weight. The bond_weight at every bond's
+# midpoint is overlaid as a thin line segment coloured the same way,
+# so the geometry of each envelope is immediately legible.
+using ITensorModels
+using LatticeCore
+using LatticeCore: num_sites, position, positions, bonds
+using Lattice2D
+using Plots
+
+const L = 8
+
+lat = Lattice2D.honeycomb(L, L; boundary=OpenAxis())
+ps = collect(positions(lat))
+xs = [p[1] for p in ps]
+ys = [p[2] for p in ps]
+
+panels = [
+    ("spherical_ssd (inscribed)",     spherical_ssd(lat; radius=:inscribed)),
+    ("spherical_ssd (circumscribed)", spherical_ssd(lat; radius=:circumscribed)),
+    ("spherical_ssd (N=4)",           spherical_ssd(lat; radius=:circumscribed, N=4)),
+    ("cylindrical_ssd (axis=1)",      cylindrical_ssd(lat; axis=1)),
+    ("cylindrical_ssd (axis=2)",      cylindrical_ssd(lat; axis=2)),
+    ("rectangular_ssd",               rectangular_ssd(lat)),
+]
+
+plts = []
+for (title, env) in panels
+    ws = [ITensorModels.site_weight(env, lat, k) for k in 1:num_sites(lat)]
+    p = scatter(
+        xs, ys; marker_z=ws, c=:viridis, ms=8, msw=0.4,
+        clims=(0.0, 1.0), aspect_ratio=:equal, title=title,
+        xlabel="x", ylabel="y", framestyle=:box, legend=false,
+        colorbar=true,
+    )
+    # Overlay bond midpoints coloured by bond_weight for visual continuity.
+    for b in bonds(lat)
+        ri = position(lat, b.i)
+        rj = position(lat, b.j)
+        wb = ITensorModels.bond_weight(env, lat, b.i, b.j)
+        col = cgrad(:viridis, [0.0, 1.0])[wb]
+        plot!(p, [ri[1], rj[1]], [ri[2], rj[2]]; color=col, lw=1.0, label="")
+    end
+    push!(plts, p)
+end
+
+p_all = plot(
+    plts...; layout=(3, 2), size=(1100, 1500),
+    plot_title="ND modulation envelopes on honeycomb($L, $L) — site_weight scatter",
+)
+
+outdir = joinpath(@__DIR__, "out")
+mkpath(outdir)
+savefig(p_all, joinpath(outdir, "honeycomb_envelopes.png"))
+println("Wrote: ", joinpath("out", "honeycomb_envelopes.png"))


### PR DESCRIPTION
## Summary

PR #6 (final) of the stacked feat/modulation-2d-* chain. Adds a self-contained `examples/` directory with three plot scripts that visualise every envelope shape introduced across PRs #1-#5.

| Script | Visualises |
|--------|------------|
| `plot_modulation_1d.jl` | 1D `AbstractModulation` envelopes (`SSD`, `SinPower{N}`, `SmoothBoundary`) -- site_weight and bond_weight on a length-60 chain. |
| `plot_modulation_2d_continuous.jl` | 2D heatmaps of the radial envelopes on a continuous grid (rectangular / cylindrical / spherical inscribed+circumscribed / sin-power N=4 / cosine ramp). |
| `plot_modulation_honeycomb_scatter.jl` | All six factory envelopes (spherical inscribed/circumscribed/N=4, cylindrical axis=1/axis=2, rectangular) sampled on `Lattice2D.honeycomb(8, 8)`, scatter-plotted with site_weight colouring and bond-midpoint overlay. |

`examples/Project.toml` develops the parent package so script edits land immediately. `examples/README.md` documents setup and invocation. `examples/out/` (PNG output directory) added to `.gitignore`.

The honeycomb scatter is particularly load-bearing: it makes the geometric character of each factory immediately legible -- the inscribed sphere kills the corners, the circumscribed sphere only zeroes the far corner, the cylindrical variants generate parallel stripes orthogonal to the chosen axis, and the rectangular axis-product gives the characteristic rhombic profile.

## Test plan

- examples/Project.toml resolves cleanly (`Pkg.instantiate()`).
- All three scripts run headlessly to completion and write PNGs into `examples/out/`.
- No change to src/, ext/, or test/; the package test suite is untouched.

## Stack

Based on #34 (feat/modulation-2d-05-factories). This is the final PR in the modulation-2d chain.

## Chain summary (PRs #30 -> #35)

1. #30 foundation -- types, formulas, lattice-free unit tests
2. #31 lattice-ext -- center_position / distance_at / site_weight / bond_weight on AbstractLattice
3. #32 modulated-lattice -- ModulatedLatticeModel wrapper + Hamiltonian assembly
4. #33 1d-equivalence regression
5. #34 user-facing factories
6. #35 (this) examples / plot scripts

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
