### PR TITLE
refactor(modulation): #8 polish - dedup helpers, cache onsite submodel, extension-missing fallbacks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.6.6"
+version = "0.6.7"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/ext/LatticeCoreExt.jl
+++ b/ext/LatticeCoreExt.jl
@@ -137,15 +137,7 @@ Midpoint of the axis-aligned bounding box, `(min(r_k) + max(r_k)) / 2`
 per axis.
 """
 function ITensorModels.center_position(::BoundingBoxCenter, lat::AbstractLattice)
-    N = num_sites(lat)
-    N >= 1 || error("center_position: lattice has zero sites")
-    lo = position(lat, 1)
-    hi = lo
-    for k in 2:N
-        p = position(lat, k)
-        lo = min.(lo, p)
-        hi = max.(hi, p)
-    end
+    lo, hi = _bounding_extent(lat)
     return (lo + hi) / 2
 end
 
@@ -224,30 +216,29 @@ end
 # ---------------------------------------------------------------------
 
 """
-    _onsite_submodel_for(m::LatticeModel, k::Int)
+    _onsite_submodels_for_all(m::LatticeModel) -> Vector
 
-Return the submodel whose `onsite_term` is used at lattice site `k`.
-Iterates the bonds touching `k`; if every touching bond resolves to the
-same submodel (via `_lookup_bond_model`), returns it. If the touching
-bonds resolve to **different** submodels, raises — per-site model
-overrides are not supported yet, and silently picking the first match
-would yield a wrong on-site field on heterogeneous lattices.
-
-All bundled models (`TFIM`, `TFIML`, `XXZ1D`, `Heisenberg1D`) have
-site-uniform on-site terms, so on a homogeneous `Dict(:nearest => sub)`
-this collapses to a single submodel as before.
+Resolve the on-site submodel for every site in a single pass over
+`bonds(m.lattice)`. Returns a vector indexed by site number. Raises if
+two bonds touching the same site resolve to different submodels
+(per-site overrides are not supported yet) or if any site is
+untouched by bonds. Replaces the previous `_onsite_submodel_for(m, k)`
+per-site helper, which was O(N_bonds) per call and therefore O(N_sites
+× N_bonds) when invoked from the `local_ham_terms` inner loop.
 """
-function _onsite_submodel_for(m::LatticeModel, k::Int)
-    first_sub = nothing
+function _onsite_submodels_for_all(m::LatticeModel)
+    Nsite = num_sites(m.lattice)
+    subs = Vector{Any}(undef, Nsite)
+    fill!(subs, nothing)
     for b in bonds(m.lattice)
-        if b.i == k || b.j == k
-            sub = _lookup_bond_model(m, b.type)
-            if first_sub === nothing
-                first_sub = sub
-            elseif !(sub === first_sub)
+        sub = _lookup_bond_model(m, b.type)
+        for k in (b.i, b.j)
+            if subs[k] === nothing
+                subs[k] = sub
+            elseif !(subs[k] === sub)
                 error(
                     "ModulatedLatticeModel: site $k is touched by bonds resolving " *
-                    "to different submodels ($(typeof(first_sub)) vs $(typeof(sub))). " *
+                    "to different submodels ($(typeof(subs[k])) vs $(typeof(sub))). " *
                     "Per-site model overrides are not yet supported; either make " *
                     "bond_models map every touching bond type to the same submodel " *
                     "instance, or wait for a future `onsite_submodel_for_site` accessor.",
@@ -255,11 +246,13 @@ function _onsite_submodel_for(m::LatticeModel, k::Int)
             end
         end
     end
-    first_sub === nothing && error(
-        "ModulatedLatticeModel: no bond touches site $k; cannot resolve " *
-        "onsite_term submodel.",
-    )
-    return first_sub
+    for k in 1:Nsite
+        subs[k] === nothing && error(
+            "ModulatedLatticeModel: no bond touches site $k; cannot resolve " *
+            "onsite_term submodel.",
+        )
+    end
+    return subs
 end
 
 """
@@ -292,6 +285,9 @@ function ITensorModels.local_ham_terms(
     # `center_position` is O(N_sites); calling `bond_weight` / `site_weight`
     # from the loops would recompute it for every term.
     r_c = ITensorModels.center_position(env.center, lat)
+    # Resolve every site's on-site submodel in a single bond-pass instead
+    # of an O(N_sites × N_bonds) per-site scan.
+    onsite_subs = _onsite_submodels_for_all(base)
     terms = OpSum[]
     for b in bonds(lat)
         sub = _lookup_bond_model(base, b.type)
@@ -301,10 +297,9 @@ function ITensorModels.local_ham_terms(
         push!(terms, fb * bond_coupling_term(sub, ord[b.i], ord[b.j]))
     end
     for k in 1:num_sites(lat)
-        sub = _onsite_submodel_for(base, k)
         d_k = distance_at_position(env.distance, position(lat, k), r_c)
         fk = profile_value(env.profile, d_k)
-        push!(terms, fk * onsite_term(sub, ord[k]))
+        push!(terms, fk * onsite_term(onsite_subs[k], ord[k]))
     end
     return terms
 end

--- a/src/core/modulation_nd.jl
+++ b/src/core/modulation_nd.jl
@@ -149,7 +149,7 @@ function distance_at_position end
 # from both the core module and the extension.
 
 function distance_at_position(::EuclideanDistance, r, r_c)
-    s = zero(_promote_real(r, r_c))
+    s = float(zero(promote_type(eltype(r), eltype(r_c))))
     @inbounds for d in eachindex(r)
         δ = r[d] - r_c[d]
         s += δ * δ
@@ -163,7 +163,7 @@ end
 
 function distance_at_position(d::PerpendicularDistance, r, r_c)
     a = d.axis
-    s = zero(_promote_real(r, r_c))
+    s = float(zero(promote_type(eltype(r), eltype(r_c))))
     @inbounds for k in eachindex(r)
         k == a && continue
         δ = r[k] - r_c[k]
@@ -174,11 +174,6 @@ end
 
 function distance_at_position(::AxisProductDistance, r, r_c)
     return ntuple(d -> abs(r[d] - r_c[d]), length(r))
-end
-
-@inline function _promote_real(r, r_c)
-    T = promote_type(eltype(r), eltype(r_c))
-    return float(zero(T))
 end
 
 # ---------------------------------------------------------------------
@@ -327,11 +322,16 @@ function profile_value(p::CosineRampProfile, d::Real)
 end
 
 # AxisProduct path: distance is a tuple, profile carries per-axis radii.
+# Bodies inline the same scalar formula used by the `Real`-distance
+# methods above; an explicit private helper is not used because the
+# expression is short and the duplication is the single point of
+# correspondence between the two paths.
 
 function profile_value(p::SinSquareProfile, ds::Tuple{Vararg{Real}})
     val = 1.0
     @inbounds for d in eachindex(ds)
-        val *= _axis_sin_square(ds[d], float(p.R[d]))
+        x, R = float(ds[d]), float(p.R[d])
+        val *= x >= R ? 0.0 : 1 - sin(pi * x / (2R))^2
     end
     return val
 end
@@ -339,7 +339,8 @@ end
 function profile_value(p::SinPowerProfile{N}, ds::Tuple{Vararg{Real}}) where {N}
     val = 1.0
     @inbounds for d in eachindex(ds)
-        val *= _axis_sin_power(ds[d], float(p.R[d]), N)
+        x, R = float(ds[d]), float(p.R[d])
+        val *= x >= R ? 0.0 : 1 - sin(pi * x / (2R))^N
     end
     return val
 end
@@ -352,16 +353,6 @@ function profile_value(::CosineRampProfile, ::Tuple{Vararg{Real}})
         "(EuclideanDistance / AxialDistance / PerpendicularDistance) " *
         "for the cosine ramp.",
     )
-end
-
-@inline function _axis_sin_square(d::Real, R::Real)
-    d >= R && return 0.0
-    return 1 - sin(pi * d / (2R))^2
-end
-
-@inline function _axis_sin_power(d::Real, R::Real, N::Integer)
-    d >= R && return 0.0
-    return 1 - sin(pi * d / (2R))^N
 end
 
 # ---------------------------------------------------------------------
@@ -385,9 +376,14 @@ site_weight(env, lat, k)    = f(position(lat, k))
 bond_weight(env, lat, i, j) = f((position(lat, i) + position(lat, j)) / 2)   # midpoint
 ```
 
-The midpoint convention for `bond_weight` matches the existing 1D
-`bond_weight(SSD, i, L) = sin²(π i / L)` rule (site at half-integer
-`i − 1/2`, bond at integer `i`).
+The midpoint convention is a geometric choice on real-space positions
+and is the analogue — not a literal port — of the 1D
+`bond_weight(SSD, i, L) = sin²(π i / L)` rule, where on the unit-spacing
+1D chain the integer bond index `i` happens to coincide with the
+Cartesian midpoint of the bond. The two conventions agree on the
+unit-spacing 1D chain and intentionally diverge from LatticeCore's
+two-endpoint arithmetic mean `(f(r_i) + f(r_j)) / 2`; see decision D2
+in `docs/src/design/modulation_nd.md`.
 """
 struct RadialEnvelope{C<:AbstractCenter,D<:AbstractDistance,P<:AbstractProfile} <:
        AbstractModulationND
@@ -472,3 +468,40 @@ Evaluate the distance metric at lattice site `k`. Defers to
 `LatticeCoreExt`.
 """
 function distance_at end
+
+# ---------------------------------------------------------------------
+# Extension-missing fallbacks
+# ---------------------------------------------------------------------
+# When the `LatticeCoreExt` extension is not loaded, the lattice-bound
+# methods (`center_position(c, lat)`, `distance_at(dist, lat, k, r_c)`,
+# `site_envelope`, `site_weight(env, lat, k)`, `bond_weight(env, lat,
+# i, j)`) have no methods. Without the fallbacks below, calling them
+# yields an opaque `MethodError` with no hint that the user needs to
+# `using LatticeCore`. Each fallback dispatches on `Any` for the
+# lattice argument; the extension's `AbstractLattice` methods are
+# strictly more specific and take precedence when loaded.
+
+const _LATTICE_EXT_HINT =
+    "lives in the `LatticeCoreExt` package extension. Add `LatticeCore` " *
+    "to your project and load it (`using LatticeCore`) before constructing " *
+    "lattice-bound modulation envelopes."
+
+function center_position(::AbstractCenter, lat)
+    return error("center_position(::AbstractCenter, lat) " * _LATTICE_EXT_HINT)
+end
+
+function distance_at(::AbstractDistance, lat, ::Int, _r_c)
+    return error("distance_at(::AbstractDistance, lat, k, r_c) " * _LATTICE_EXT_HINT)
+end
+
+function site_envelope(::RadialEnvelope, lat, ::Int)
+    return error("site_envelope(::RadialEnvelope, lat, k) " * _LATTICE_EXT_HINT)
+end
+
+function site_weight(::AbstractModulationND, lat, ::Int)
+    return error("site_weight(::AbstractModulationND, lat, k) " * _LATTICE_EXT_HINT)
+end
+
+function bond_weight(::AbstractModulationND, lat, ::Int, ::Int)
+    return error("bond_weight(::AbstractModulationND, lat, i, j) " * _LATTICE_EXT_HINT)
+end


### PR DESCRIPTION
## Summary

PR #8 (polish) on the stacked feat/modulation-2d-* chain. Addresses the advisory-tier findings from the multi-agent /review-pr report. No behaviour change for valid inputs; all changes are internal cleanups + nicer error messages.

### Changes

- **A1** Reworded the bond_weight midpoint docstring on RadialEnvelope to explain that the convention is geometric (Cartesian midpoint of the bond), and that the 1D `bond_weight(SSD, i, L)` integer-index rule is the analogue rather than a literal port. Added pointer to design decision D2.

- **A2** Dropped the private `_axis_sin_square` / `_axis_sin_power` helpers. The AxisProduct-path `profile_value` bodies now inline the same scalar formula used by the Real-distance methods, with explicit comments noting the duplication.

- **A3** Dropped the `_promote_real` helper. The two call sites in `distance_at_position` now inline `float(zero(promote_type(eltype(r), eltype(r_c))))` directly.

- **A4** `center_position(::BoundingBoxCenter, lat)` now reuses `_bounding_extent` instead of duplicating the min/max bounding loop.

- **A6** Replaced `_onsite_submodel_for(m, k)` (O(N_bonds) per call, invoked N_sites times → O(N_sites × N_bonds)) with `_onsite_submodels_for_all(m)`, a single O(N_bonds) pass that returns a per-site submodel vector. `local_ham_terms` caches the vector once and indexes into it in the inner loop.

- **A7** Added fallback methods on `center_position` / `distance_at` / `site_envelope` / `site_weight(::AbstractModulationND, lat, k)` / `bond_weight(::AbstractModulationND, lat, i, j)` that raise a helpful error pointing users at the `LatticeCoreExt` extension. The `AbstractLattice`-typed methods in the extension are strictly more specific and continue to win when `LatticeCore` is loaded.

Skipped:
- **A5** The `Val(N)` dispatch in `_make_profile` is the canonical Julia idiom for runtime-N → type-stable construction; the `SinPowerProfile{2} ≡ SinSquareProfile` numerical equivalence is already covered by tests, and there is no perf gain to recover from specialisation since N is already a type parameter.

## Test plan

- Pkg.test() green (694 / 694 passing). No test added or removed.
- Existing happy-path constructions and Hamiltonian builds all still pass with no numerical change.

## Stack

Based on #36 (feat/modulation-2d-07-validation-hardening), which is based on the rest of the chain (#30..#35). Final PR in the modulation-2d series.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
