### PR TITLE
fix(modulation): #9 polish-fixups - type-stable cache, better fallback errors, fallback tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.6.7"
+version = "0.6.8"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/ext/LatticeCoreExt.jl
+++ b/ext/LatticeCoreExt.jl
@@ -197,10 +197,11 @@ end
 """
     bond_weight(env::AbstractModulationND, lat::AbstractLattice, i::Int, j::Int)
 
-ND `bond_weight`: midpoint evaluation
-`f((r_i + r_j) / 2)`. Matches the 1D convention
-`bond_weight(SSD, i, L) = sin²(π i / L)` (sites at half-integer
-positions, bond midpoints at integers).
+ND `bond_weight`: geometric midpoint evaluation `f((r_i + r_j) / 2)`.
+This is the Cartesian-position analogue of the 1D rule
+`bond_weight(SSD, i, L) = sin²(π i / L)` — on a unit-spacing 1D chain
+the integer bond index `i` coincides with the Cartesian midpoint. See
+the docstring on [`RadialEnvelope`](@ref) for the full discussion.
 """
 function ITensorModels.bond_weight(
     env::RadialEnvelope, lat::AbstractLattice, i::Int, j::Int
@@ -219,16 +220,25 @@ end
     _onsite_submodels_for_all(m::LatticeModel) -> Vector
 
 Resolve the on-site submodel for every site in a single pass over
-`bonds(m.lattice)`. Returns a vector indexed by site number. Raises if
-two bonds touching the same site resolve to different submodels
-(per-site overrides are not supported yet) or if any site is
-untouched by bonds. Replaces the previous `_onsite_submodel_for(m, k)`
-per-site helper, which was O(N_bonds) per call and therefore O(N_sites
-× N_bonds) when invoked from the `local_ham_terms` inner loop.
+`bonds(m.lattice)`. Returns a vector indexed by site number whose
+element type is the concrete value type of `m.bond_models` (so the
+downstream `onsite_term(subs[k], ...)` call dispatches statically on
+homogeneous lattices). Raises if two bonds touching the same site
+resolve to different submodels (per-site overrides are not supported
+yet) or if any site is untouched by bonds. Replaces the previous
+`_onsite_submodel_for(m, k)` per-site helper, which was worst-case
+O(N_bonds) per call and therefore worst-case O(N_sites × N_bonds) when
+invoked from the `local_ham_terms` inner loop.
 """
 function _onsite_submodels_for_all(m::LatticeModel)
     Nsite = num_sites(m.lattice)
-    subs = Vector{Any}(undef, Nsite)
+    # The element type is the concrete value type of bond_models. For a
+    # homogeneous `Dict(:nearest => sub)` this is `typeof(sub)`; for a
+    # heterogeneous dict it widens to the smallest type covering every
+    # value, which still avoids the `Vector{Any}` boxing that would
+    # force runtime dispatch on every onsite_term call.
+    T = valtype(m.bond_models)
+    subs = Vector{Union{Nothing,T}}(undef, Nsite)
     fill!(subs, nothing)
     for b in bonds(m.lattice)
         sub = _lookup_bond_model(m, b.type)
@@ -246,13 +256,16 @@ function _onsite_submodels_for_all(m::LatticeModel)
             end
         end
     end
+    out = Vector{T}(undef, Nsite)
     for k in 1:Nsite
-        subs[k] === nothing && error(
+        v = subs[k]
+        v === nothing && error(
             "ModulatedLatticeModel: no bond touches site $k; cannot resolve " *
             "onsite_term submodel.",
         )
+        out[k] = v
     end
-    return subs
+    return out
 end
 
 """

--- a/src/core/modulation_nd.jl
+++ b/src/core/modulation_nd.jl
@@ -381,9 +381,10 @@ and is the analogue — not a literal port — of the 1D
 `bond_weight(SSD, i, L) = sin²(π i / L)` rule, where on the unit-spacing
 1D chain the integer bond index `i` happens to coincide with the
 Cartesian midpoint of the bond. The two conventions agree on the
-unit-spacing 1D chain and intentionally diverge from LatticeCore's
-two-endpoint arithmetic mean `(f(r_i) + f(r_j)) / 2`; see decision D2
-in `docs/src/design/modulation_nd.md`.
+unit-spacing 1D chain. The choice of midpoint evaluation (rather than
+LatticeCore's two-endpoint arithmetic mean `(f(r_i) + f(r_j)) / 2`) is
+recorded as decision D2 in `docs/src/design/modulation_nd.md`; the
+prose of that document gives the full motivation.
 """
 struct RadialEnvelope{C<:AbstractCenter,D<:AbstractDistance,P<:AbstractProfile} <:
        AbstractModulationND
@@ -481,27 +482,41 @@ function distance_at end
 # lattice argument; the extension's `AbstractLattice` methods are
 # strictly more specific and take precedence when loaded.
 
-const _LATTICE_EXT_HINT =
-    "lives in the `LatticeCoreExt` package extension. Add `LatticeCore` " *
-    "to your project and load it (`using LatticeCore`) before constructing " *
-    "lattice-bound modulation envelopes."
+"""
+    _missing_lat_msg(sig, lat) -> String
+
+Build the error string for an extension-missing fallback. Names the
+function signature, reports `typeof(lat)`, and instructs the user to
+load `LatticeCore`. Covers both possible diagnoses: the caller may
+have forgotten `using LatticeCore`, *or* the extension is already
+loaded but they passed a non-`AbstractLattice` value where one was
+expected.
+"""
+function _missing_lat_msg(sig::AbstractString, lat)
+    return "$(sig): no method for lat::$(typeof(lat)). This function is " *
+           "supplied by the `LatticeCoreExt` package extension and only " *
+           "defines methods on `LatticeCore.AbstractLattice`. If you have " *
+           "not yet loaded LatticeCore, add it to your project and " *
+           "`using LatticeCore`. If LatticeCore is loaded, check the " *
+           "`lat` argument — it must be an `AbstractLattice`."
+end
 
 function center_position(::AbstractCenter, lat)
-    return error("center_position(::AbstractCenter, lat) " * _LATTICE_EXT_HINT)
+    return error(_missing_lat_msg("center_position(::AbstractCenter, lat)", lat))
 end
 
 function distance_at(::AbstractDistance, lat, ::Int, _r_c)
-    return error("distance_at(::AbstractDistance, lat, k, r_c) " * _LATTICE_EXT_HINT)
+    return error(_missing_lat_msg("distance_at(::AbstractDistance, lat, k, r_c)", lat))
 end
 
 function site_envelope(::RadialEnvelope, lat, ::Int)
-    return error("site_envelope(::RadialEnvelope, lat, k) " * _LATTICE_EXT_HINT)
+    return error(_missing_lat_msg("site_envelope(::RadialEnvelope, lat, k)", lat))
 end
 
 function site_weight(::AbstractModulationND, lat, ::Int)
-    return error("site_weight(::AbstractModulationND, lat, k) " * _LATTICE_EXT_HINT)
+    return error(_missing_lat_msg("site_weight(::AbstractModulationND, lat, k)", lat))
 end
 
 function bond_weight(::AbstractModulationND, lat, ::Int, ::Int)
-    return error("bond_weight(::AbstractModulationND, lat, i, j) " * _LATTICE_EXT_HINT)
+    return error(_missing_lat_msg("bond_weight(::AbstractModulationND, lat, i, j)", lat))
 end

--- a/test/base/test_modulation_nd_extension_missing.jl
+++ b/test/base/test_modulation_nd_extension_missing.jl
@@ -1,0 +1,92 @@
+# Regression tests for the "extension-missing" fallback methods added
+# in PR #37 (advisory A7) and refined in PR #9 (I2) to include
+# typeof(lat) in the error message.
+#
+# In the test environment LatticeCoreExt IS loaded, so the
+# AbstractLattice-typed methods win for actual lattice arguments. The
+# fallbacks fire when the caller passes a non-AbstractLattice value as
+# `lat`. We exercise that path by calling each fallback with a Dict
+# (clearly not an AbstractLattice) and asserting the error message
+# names both the function signature and the offending type.
+
+using ITensorModels
+using LatticeCore
+using Test
+
+const _BOGUS_LAT = Dict(:x => 1)
+
+@testset "Extension-missing fallback: center_position" begin
+    try
+        ITensorModels.center_position(BoundingBoxCenter(), _BOGUS_LAT)
+        @test false
+    catch e
+        @test e isa ErrorException
+        @test occursin("center_position", e.msg)
+        @test occursin("Dict", e.msg)
+        @test occursin("LatticeCore", e.msg)
+    end
+end
+
+@testset "Extension-missing fallback: distance_at" begin
+    try
+        ITensorModels.distance_at(EuclideanDistance(), _BOGUS_LAT, 1, [0.0, 0.0])
+        @test false
+    catch e
+        @test e isa ErrorException
+        @test occursin("distance_at", e.msg)
+        @test occursin("Dict", e.msg)
+        @test occursin("LatticeCore", e.msg)
+    end
+end
+
+@testset "Extension-missing fallback: site_envelope" begin
+    env = RadialEnvelope(BoundingBoxCenter(), EuclideanDistance(), SinSquareProfile(3.0))
+    try
+        ITensorModels.site_envelope(env, _BOGUS_LAT, 1)
+        @test false
+    catch e
+        @test e isa ErrorException
+        @test occursin("site_envelope", e.msg)
+        @test occursin("Dict", e.msg)
+        @test occursin("LatticeCore", e.msg)
+    end
+end
+
+@testset "Extension-missing fallback: site_weight (ND signature)" begin
+    env = RadialEnvelope(BoundingBoxCenter(), EuclideanDistance(), SinSquareProfile(3.0))
+    try
+        ITensorModels.site_weight(env, _BOGUS_LAT, 1)
+        @test false
+    catch e
+        @test e isa ErrorException
+        @test occursin("site_weight", e.msg)
+        @test occursin("Dict", e.msg)
+        @test occursin("LatticeCore", e.msg)
+    end
+end
+
+@testset "Extension-missing fallback: bond_weight (ND signature)" begin
+    env = RadialEnvelope(BoundingBoxCenter(), EuclideanDistance(), SinSquareProfile(3.0))
+    try
+        ITensorModels.bond_weight(env, _BOGUS_LAT, 1, 2)
+        @test false
+    catch e
+        @test e isa ErrorException
+        @test occursin("bond_weight", e.msg)
+        @test occursin("Dict", e.msg)
+        @test occursin("LatticeCore", e.msg)
+    end
+end
+
+@testset "1D site_weight / bond_weight signatures are NOT shadowed" begin
+    # The 1D (mod, i::Int, L::Int) signatures must still resolve to the
+    # 1D AbstractModulation methods even though RadialEnvelope is also
+    # an AbstractModulationND. The ND fallbacks live at
+    # (::AbstractModulationND, lat::Any, ::Int) and
+    # (::AbstractModulationND, lat::Any, ::Int, ::Int) -- different
+    # second/third positional argument types from the 1D protocol so
+    # dispatch is unambiguous.
+    L = 60
+    @test ITensorModels.site_weight(SSD(), 30, L) > 0
+    @test ITensorModels.bond_weight(SSD(), 30, L) > 0
+end


### PR DESCRIPTION
## Summary

PR #9 (polish-fixups) on the stacked feat/modulation-2d-* chain. Addresses the five Important items raised by the /review-pr aggregated report on PR #37.

### Changes

- **I1** `_onsite_submodels_for_all` no longer returns `Vector{Any}`. Cache is now typed `Vector{T}` where `T = valtype(m.bond_models)`, so `onsite_term(subs[k], ord[k])` dispatches statically on homogeneous lattices and the asymptotic perf gain claimed by PR #37 is actually realised.
- **I2** Fallback errors now include `typeof(lat)` and cover both diagnoses (LatticeCore not loaded vs. LatticeCore loaded with a non-AbstractLattice argument). Implementation via a shared `_missing_lat_msg(sig, lat)` helper.
- **I3** New `test/base/test_modulation_nd_extension_missing.jl` exercises every fallback (`center_position` / `distance_at` / `site_envelope` / `site_weight` / `bond_weight`) with a `Dict`-as-lat probe and asserts error type, function-name substring, `typeof(lat)` substring, and LatticeCore mention. Bonus testset confirms the 1D `AbstractModulation` `site_weight` / `bond_weight` signatures are NOT shadowed by the ND fallbacks.
- **I4** `LatticeCoreExt` `bond_weight` docstring no longer says matches the 1D convention — now uses the same analogue, not a literal port framing as the RadialEnvelope docstring and cross-references it.
- **I5** RadialEnvelope docstring no longer claims D2 documents the LatticeCore divergence (D2 is the bare midpoint evaluation decision); the divergence attribution moved to the design doc prose body.

## Test plan

- Pkg.test() green (716 / 716 passing, was 694; +22 from `test_modulation_nd_extension_missing.jl`).
- All five fallback methods regress against `@test ErrorException + occursin(typeof(lat))`.
- 1D vs ND signature non-shadowing confirmed.

## Stack

Based on #37 (`feat/modulation-2d-08-polish`). This is the last PR in the modulation-2d chain unless the next /review-pr surfaces more.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
