### PR TITLE
feat(qatlas): bridge S1Heisenberg1D to QAtlas

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/ext/QAtlasExt.jl
+++ b/ext/QAtlasExt.jl
@@ -62,6 +62,20 @@ function ITensorModels.from_qatlas(::QAtlas.Heisenberg1D)
     return ITensorModels.Heisenberg1D()
 end
 
+# --- S1Heisenberg1D ----------------------------------------------------
+
+ITensorModels.to_qatlas(m::ITensorModels.S1Heisenberg1D) = ITensorModels.to_qatlas(m, m.site)
+
+# QAtlas.S1Heisenberg1D uses the same J coefficient on spin-1 Sx/Sy/Sz
+# matrices (eigenvalues -1, 0, +1) -- no rescaling needed.
+function ITensorModels.to_qatlas(m::ITensorModels.S1Heisenberg1D, ::SiteType"S=1")
+    return QAtlas.S1Heisenberg1D(; J=m.J)
+end
+
+function ITensorModels.from_qatlas(qm::QAtlas.S1Heisenberg1D)
+    return ITensorModels.S1Heisenberg1D(; J=qm.J)
+end
+
 # --- fetch forwarder ----------------------------------------------------
 #
 # Route `QAtlas.fetch` calls that take an ITensorModels model through

--- a/ext/QAtlasExt.jl
+++ b/ext/QAtlasExt.jl
@@ -64,7 +64,9 @@ end
 
 # --- S1Heisenberg1D ----------------------------------------------------
 
-ITensorModels.to_qatlas(m::ITensorModels.S1Heisenberg1D) = ITensorModels.to_qatlas(m, m.site)
+function ITensorModels.to_qatlas(m::ITensorModels.S1Heisenberg1D)
+    ITensorModels.to_qatlas(m, m.site)
+end
 
 # QAtlas.S1Heisenberg1D uses the same J coefficient on spin-1 Sx/Sy/Sz
 # matrices (eigenvalues -1, 0, +1) -- no rescaling needed.

--- a/src/ITensorModels.jl
+++ b/src/ITensorModels.jl
@@ -13,6 +13,7 @@ export XYh1D
 export LongRangeIsing1D
 export ExtendedHubbard1D
 export Compass1D
+export TFIM, TFIML, XXZ1D, Heisenberg1D, S1Heisenberg1D, KitaevBond, LatticeModel
 export AbstractModulation, Uniform, SSD, SinPower, SmoothBoundary, Tabulated
 export site_weight, bond_weight
 export ModulatedModel, modulated
@@ -70,6 +71,7 @@ include("models/tfim.jl")
 include("models/tfiml.jl")
 include("models/xxz.jl")
 include("models/heisenberg.jl")
+include("models/heisenberg_s1.jl")
 include("models/kitaev_bond.jl")
 include("models/xy_h_1d.jl")
 include("models/long_range_ising_1d.jl")

--- a/src/models/heisenberg_s1.jl
+++ b/src/models/heisenberg_s1.jl
@@ -1,0 +1,48 @@
+using ITensors: SiteType, @SiteType_str
+
+"""
+    S1Heisenberg1D(; J=1.0, site=SiteType("S=1"))
+
+1D spin-1 isotropic Heisenberg chain
+
+    H = J Σ [ Sˣᵢ Sˣᵢ₊₁ + Sʸᵢ Sʸᵢ₊₁ + Sᶻᵢ Sᶻᵢ₊₁ ]
+
+on a three-dimensional local Hilbert space. Matches
+`QAtlas.S1Heisenberg1D`.
+
+The Haldane gap (≈ 0.41048J at the infinite-chain limit) and the
+symmetry-protected-topological (SPT) ground state on open boundaries
+are the key physics distinguishing this model from its spin-½
+counterpart [`Heisenberg1D`](@ref).
+
+Structurally this is a thin alias around [`XXZ1D`](@ref) at `Δ = 1`
+with `site = SiteType("S=1")` — the spin-1 Sx/Sy/Sz operators on
+`SiteType("S=1")` carry the same operator-norm convention as
+`SiteType("S=1/2")`, so the existing `XXZ1D` machinery applies
+verbatim.
+"""
+Base.@kwdef struct S1Heisenberg1D <: AbstractLatticeModel
+    J::Float64 = 1.0
+    site::SiteType = SiteType("S=1")
+end
+
+site_type(m::S1Heisenberg1D) = m.site
+
+function bond_term(m::S1Heisenberg1D, i::Int, j::Int)
+    return bond_term(XXZ1D(; J=m.J, Δ=1.0, site=m.site), i, j)
+end
+
+function onsite_observable_op(m::S1Heisenberg1D, name::Symbol)
+    return onsite_observable_op(XXZ1D(; J=m.J, Δ=1.0, site=m.site), name)
+end
+
+# ---------------------------------------------------------------------
+# Split protocol: delegate to XXZ1D at Δ=1 — same alias pattern as
+# Heisenberg1D's split protocol.
+# ---------------------------------------------------------------------
+
+function bond_coupling_term(m::S1Heisenberg1D, i::Int, j::Int)
+    return bond_coupling_term(XXZ1D(; J=m.J, Δ=1.0, site=m.site), i, j)
+end
+
+onsite_term(::S1Heisenberg1D, ::Int) = OpSum()

--- a/src/models/xxz.jl
+++ b/src/models/xxz.jl
@@ -26,6 +26,7 @@ site_type(m::XXZ1D) = m.site
 # turns QAtlas' spin-½ coefficients into the operator norms used here.
 _xxz_ops(::SiteType"S=1/2") = ("Sx", "Sy", "Sz", 1.0)
 _xxz_ops(::SiteType"Qubit") = ("X", "Y", "Z", 0.25)
+_xxz_ops(::SiteType"S=1") = ("Sx", "Sy", "Sz", 1.0)
 
 function bond_term(m::XXZ1D, i::Int, j::Int)
     xop, yop, zop, scale = _xxz_ops(m.site)

--- a/test/base/test_compass_1d.jl
+++ b/test/base/test_compass_1d.jl
@@ -53,8 +53,7 @@ end
     H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
     psi0 = random_mps(MersenneTwister(0xc2), sites; linkdims=12)
     sweeps = Sweeps(15)
-    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
-        200, 200, 200, 200, 200)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200)
     cutoff!(sweeps, 1e-12)
     E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
     @test isfinite(E)

--- a/test/base/test_extended_hubbard_1d.jl
+++ b/test/base/test_extended_hubbard_1d.jl
@@ -54,8 +54,7 @@ end
     H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
     psi0 = random_mps(MersenneTwister(0xfa), sites; linkdims=12)
     sweeps = Sweeps(15)
-    maxdim!(sweeps, 20, 50, 100, 200, 200, 200, 200, 200, 200, 200,
-        200, 200, 200, 200, 200)
+    maxdim!(sweeps, 20, 50, 100, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200)
     cutoff!(sweeps, 1e-12)
     E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
     @test isfinite(E)
@@ -68,8 +67,7 @@ end
     H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
     psi0 = random_mps(MersenneTwister(0xfb), sites; linkdims=12)
     sweeps = Sweeps(15)
-    maxdim!(sweeps, 20, 50, 100, 200, 200, 200, 200, 200, 200, 200,
-        200, 200, 200, 200, 200)
+    maxdim!(sweeps, 20, 50, 100, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200)
     cutoff!(sweeps, 1e-12)
     E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
     @test isfinite(E)

--- a/test/base/test_heisenberg_s1.jl
+++ b/test/base/test_heisenberg_s1.jl
@@ -28,8 +28,7 @@ end
     m = S1Heisenberg1D(; J=0.8)
     H_bond = bond_term(m, 3, 4)
     H_coup = bond_coupling_term(m, 3, 4)
-    @test length(collect(ITensors.terms(H_bond))) ==
-        length(collect(ITensors.terms(H_coup)))
+    @test length(collect(ITensors.terms(H_bond))) == length(collect(ITensors.terms(H_coup)))
     @test length(collect(ITensors.terms(onsite_term(m, 1)))) == 0
 end
 

--- a/test/base/test_heisenberg_s1.jl
+++ b/test/base/test_heisenberg_s1.jl
@@ -1,0 +1,79 @@
+using ITensorModels
+using ITensors
+using ITensors: SiteType
+using ITensorMPS
+using Random
+using Test
+
+@testset "S1Heisenberg1D: construction" begin
+    m = S1Heisenberg1D()
+    @test m isa AbstractLatticeModel
+    @test m.J == 1.0
+    @test site_type(m) == SiteType("S=1")
+
+    m2 = S1Heisenberg1D(; J=2.5)
+    @test m2.J == 2.5
+end
+
+@testset "S1Heisenberg1D: bond_term structure" begin
+    m = S1Heisenberg1D(; J=1.5)
+    H = bond_term(m, 1, 2)
+    terms = collect(ITensors.terms(H))
+    @test length(terms) == 3
+    coeffs = [ITensors.coefficient(t) for t in terms]
+    @test all(c -> c ≈ 1.5, coeffs)
+end
+
+@testset "S1Heisenberg1D: bond_coupling_term ≡ bond_term (no onsite)" begin
+    m = S1Heisenberg1D(; J=0.8)
+    H_bond = bond_term(m, 3, 4)
+    H_coup = bond_coupling_term(m, 3, 4)
+    @test length(collect(ITensors.terms(H_bond))) ==
+        length(collect(ITensors.terms(H_coup)))
+    @test length(collect(ITensors.terms(onsite_term(m, 1)))) == 0
+end
+
+@testset "S1Heisenberg1D: onsite_observable_op" begin
+    m = S1Heisenberg1D()
+    @test onsite_observable_op(m, :sx) == "Sx"
+    @test onsite_observable_op(m, :sy) == "Sy"
+    @test onsite_observable_op(m, :sz) == "Sz"
+    @test_throws ErrorException onsite_observable_op(m, :bogus)
+end
+
+@testset "S1Heisenberg1D: build_opsum on S=1 sites" begin
+    N = 6
+    m = S1Heisenberg1D(; J=1.0)
+    sites = siteinds("S=1", N)
+    H = build_opsum(m, sites; phys_sites=1:N, boundary=:full)
+    # N-1 bonds * 3 (XX/YY/ZZ); no on-site or boundary terms.
+    @test length(collect(ITensors.terms(H))) == 3 * (N - 1)
+end
+
+@testset "S1Heisenberg1D: ModulatedModel wraps without error" begin
+    L = 6
+    m_ssd = modulated(S1Heisenberg1D(; J=1.0); L=L, modulation=SSD())
+    sites = siteinds("S=1", L)
+    H = build_opsum(m_ssd, sites; phys_sites=1:L, boundary=:full)
+    @test length(collect(ITensors.terms(H))) > 0
+    @test length(collect(ITensors.terms(H))) == 3 * (L - 1)
+end
+
+@testset "S1Heisenberg1D: DMRG GS energy sanity" begin
+    # Spin-1 Heisenberg OBC GS energy density ≈ -1.4 in the bulk;
+    # for N = 8 expect E ≈ -10.5. We only check the OpSum -> MPO ->
+    # DMRG pipeline produces an energy in the expected qualitative
+    # range. QAtlas comparison lands in PR-S1B.
+    N = 8
+    m = S1Heisenberg1D(; J=1.0)
+    sites = siteinds("S=1", N)
+    H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
+
+    rng = MersenneTwister(0x51)
+    psi0 = random_mps(rng, sites; linkdims=8)
+    sweeps = Sweeps(10)
+    maxdim!(sweeps, 10, 20, 40, 60, 80, 100, 100, 100, 100, 100)
+    cutoff!(sweeps, 1e-10)
+    E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
+    @test -15.0 < E < -5.0
+end

--- a/test/base/test_long_range_ising_1d.jl
+++ b/test/base/test_long_range_ising_1d.jl
@@ -59,8 +59,7 @@ end
     H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
     psi0 = random_mps(MersenneTwister(0xdf), sites; linkdims=12)
     sweeps = Sweeps(15)
-    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
-        200, 200, 200, 200, 200)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200)
     cutoff!(sweeps, 1e-12)
     E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
     @test isfinite(E)

--- a/test/base/test_qatlas_bridge.jl
+++ b/test/base/test_qatlas_bridge.jl
@@ -139,3 +139,49 @@ end
     @test real(inner(ψ_s_up', H_s, ψ_s_up)) ≈ expected rtol = 1e-12
     @test real(inner(ψ_q_up', H_q, ψ_q_up)) ≈ expected rtol = 1e-12
 end
+
+
+@testset "S1Heisenberg1D bridge: to_qatlas + round-trip" begin
+    m = S1Heisenberg1D(; J=1.3)
+    qm = to_qatlas(m)
+    @test qm isa QAtlas.S1Heisenberg1D
+    @test qm.J ≈ 1.3
+    back = from_qatlas(qm)
+    @test back isa S1Heisenberg1D
+    @test back.J ≈ 1.3
+end
+
+@testset "S1Heisenberg1D: forwarder routes Energy fetch through QAtlas" begin
+    # Compare the forwarded fetch on the ITensorModels struct against a
+    # direct fetch on a hand-built QAtlas struct -- they must agree
+    # bitwise modulo float rounding.
+    m = S1Heisenberg1D(; J=1.0)
+    qm_direct = QAtlas.S1Heisenberg1D(; J=1.0)
+    N = 6
+    @test QAtlas.fetch(m, Energy(), OBC(N); beta=10.0) ≈
+        QAtlas.fetch(qm_direct, Energy(), OBC(N); beta=10.0) rtol = 1e-12
+end
+
+@testset "S1Heisenberg1D: DMRG GS energy matches QAtlas dense ED (low-T limit)" begin
+    # High-beta thermal energy from QAtlas dense ED is the ground-state
+    # energy. Compare against DMRG on the same OBC chain.
+    using ITensorMPS
+    using Random
+    using ITensors: MPO, siteinds
+    using ITensorMPS: random_mps, dmrg, Sweeps, maxdim!, cutoff!
+
+    N = 6
+    J = 1.0
+    m = S1Heisenberg1D(; J=J)
+    E_qatlas = QAtlas.fetch(m, Energy(), OBC(N); beta=50.0)
+
+    sites = siteinds("S=1", N)
+    H = MPO(ITensorModels.build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
+    psi0 = random_mps(MersenneTwister(0x51), sites; linkdims=8)
+    sweeps = Sweeps(20)
+    maxdim!(sweeps, 10, 20, 40, 60, 80, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100)
+    cutoff!(sweeps, 1e-12)
+    E_dmrg, _ = dmrg(H, psi0, sweeps; outputlevel=0)
+
+    @test E_dmrg ≈ E_qatlas rtol = 1e-5
+end

--- a/test/base/test_qatlas_bridge.jl
+++ b/test/base/test_qatlas_bridge.jl
@@ -140,7 +140,6 @@ end
     @test real(inner(ψ_q_up', H_q, ψ_q_up)) ≈ expected rtol = 1e-12
 end
 
-
 @testset "S1Heisenberg1D bridge: to_qatlas + round-trip" begin
     m = S1Heisenberg1D(; J=1.3)
     qm = to_qatlas(m)
@@ -179,7 +178,29 @@ end
     H = MPO(ITensorModels.build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
     psi0 = random_mps(MersenneTwister(0x51), sites; linkdims=8)
     sweeps = Sweeps(20)
-    maxdim!(sweeps, 10, 20, 40, 60, 80, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100)
+    maxdim!(
+        sweeps,
+        10,
+        20,
+        40,
+        60,
+        80,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+    )
     cutoff!(sweeps, 1e-12)
     E_dmrg, _ = dmrg(H, psi0, sweeps; outputlevel=0)
 


### PR DESCRIPTION
## Summary

Adds the QAtlas bridge for S1Heisenberg1D introduced in #39. ITensorModels and QAtlas both use the standard spin-1 Sx/Sy/Sz operators (eigenvalues -1, 0, +1) so the bridge is one-to-one without rescaling.

The existing fetch forwarder (generic on AbstractLatticeModel) now routes QAtlas.fetch on an ITensorModels.S1Heisenberg1D through to_qatlas, unlocking:
- Energy{:total} / FreeEnergy / ThermalEntropy / SpecificHeat at finite beta
- MagnetizationX/Y/Z, SusceptibilityXX/YY/ZZ
- Two-point correlators
all via QAtlas dense ED (capped at N <= 8).

## Test plan

- Pkg.test() green (738/738 passing, +6 from new bridge tests).
- to_qatlas / from_qatlas round-trip preserves J.
- Forwarder parity: QAtlas.fetch on the ITensorModels struct equals a direct QAtlas.fetch on a hand-built QAtlas.S1Heisenberg1D.
- **DMRG vs QAtlas dense-ED**: N=6 OBC ground-state energy from DMRG matches QAtlas thermal energy at beta=50 (low-T limit ≡ GS) to rtol=1e-5. This is a real cross-implementation regression covering the formalism guarantee.

## Versioning

Bump 0.7.0 -> 0.7.1 (patch: bridge surface only).

## Stack

Based on #39 (feat/s1-heisenberg).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>