### PR TITLE
feat(models): add TightBinding1D (spinless fermion chain)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/ITensorModels.jl
+++ b/src/ITensorModels.jl
@@ -14,6 +14,7 @@ export LongRangeIsing1D
 export ExtendedHubbard1D
 export Compass1D
 export TFIM, TFIML, XXZ1D, Heisenberg1D, S1Heisenberg1D, KitaevBond, LatticeModel
+export TFIM, TFIML, XXZ1D, Heisenberg1D, KitaevBond, TightBinding1D, LatticeModel
 export AbstractModulation, Uniform, SSD, SinPower, SmoothBoundary, Tabulated
 export site_weight, bond_weight
 export ModulatedModel, modulated
@@ -77,6 +78,7 @@ include("models/xy_h_1d.jl")
 include("models/long_range_ising_1d.jl")
 include("models/extended_hubbard_1d.jl")
 include("models/compass_1d.jl")
+include("models/tightbinding_1d.jl")
 include("models/lattice_model.jl")
 include("models/modulated.jl")
 include("models/modulated_lattice.jl")

--- a/src/models/tightbinding_1d.jl
+++ b/src/models/tightbinding_1d.jl
@@ -1,0 +1,66 @@
+using ITensors: SiteType, @SiteType_str
+
+"""
+    TightBinding1D(; t=1.0, μ=0.0, site=SiteType("Fermion"))
+
+1D spinless-fermion tight-binding chain
+
+    H = -t Σ_i (c†_i c_{i+1} + c†_{i+1} c_i)  +  μ Σ_i n_i
+
+on `SiteType("Fermion")` sites. Jordan-Wigner strings between non-
+adjacent operators are inserted automatically by ITensors' OpSum →
+MPO conversion.
+
+This is the canonical free-fermion model: at half-filling (μ = 0)
+the open chain has analytic single-particle eigenvalues
+`ε_k = -2t cos(kπ/(N+1))` for `k ∈ {1, ..., N}`, and the ground-
+state energy is the sum of the negative eigenvalues. Equivalent to
+the XX chain under Jordan-Wigner transformation.
+
+QAtlas currently exposes 2D tight-binding only (Honeycomb / Kagome /
+Lieb / Triangular); a direct 1D bridge is intentionally deferred.
+"""
+Base.@kwdef struct TightBinding1D <: AbstractLatticeModel
+    t::Float64 = 1.0
+    μ::Float64 = 0.0
+    site::SiteType = SiteType("Fermion")
+end
+
+site_type(m::TightBinding1D) = m.site
+
+function bond_term(m::TightBinding1D, i::Int, j::Int)
+    H = OpSum()
+    H += -m.t, "Cdag", i, "C", j
+    H += -m.t, "Cdag", j, "C", i
+    H += (m.μ / 2), "N", i
+    H += (m.μ / 2), "N", j
+    return H
+end
+
+function boundary_patch(m::TightBinding1D, k::Int)
+    H = OpSum()
+    H += (m.μ / 2), "N", k
+    return H
+end
+
+function onsite_observable_op(m::TightBinding1D, name::Symbol)
+    name === :n && return "N"
+    name === :c && return "C"
+    name === :cdag && return "Cdag"
+    return error(
+        "TightBinding1D: unsupported onsite observable $name on site $(site_type(m))"
+    )
+end
+
+function bond_coupling_term(m::TightBinding1D, i::Int, j::Int)
+    H = OpSum()
+    H += -m.t, "Cdag", i, "C", j
+    H += -m.t, "Cdag", j, "C", i
+    return H
+end
+
+function onsite_term(m::TightBinding1D, k::Int)
+    H = OpSum()
+    H += m.μ, "N", k
+    return H
+end

--- a/test/base/test_tightbinding_1d.jl
+++ b/test/base/test_tightbinding_1d.jl
@@ -1,0 +1,79 @@
+using ITensorModels
+using ITensors
+using ITensors: SiteType
+using ITensorMPS
+using Random
+using Test
+
+@testset "TightBinding1D: construction" begin
+    m = TightBinding1D()
+    @test m isa AbstractLatticeModel
+    @test m.t == 1.0
+    @test m.μ == 0.0
+    @test site_type(m) == SiteType("Fermion")
+
+    m2 = TightBinding1D(; t=2.5, μ=-0.5)
+    @test m2.t == 2.5
+    @test m2.μ == -0.5
+end
+
+@testset "TightBinding1D: bond_coupling_term has hopping only" begin
+    m = TightBinding1D(; t=1.5, μ=0.7)
+    H_coup = bond_coupling_term(m, 1, 2)
+    terms = collect(ITensors.terms(H_coup))
+    @test length(terms) == 2
+    @test all(t -> ITensors.coefficient(t) ≈ -1.5, terms)
+end
+
+@testset "TightBinding1D: onsite_term carries full μ" begin
+    m = TightBinding1D(; t=1.0, μ=0.7)
+    H_on = onsite_term(m, 3)
+    terms = collect(ITensors.terms(H_on))
+    @test length(terms) == 1
+    @test ITensors.coefficient(terms[1]) ≈ 0.7
+end
+
+@testset "TightBinding1D: onsite_observable_op" begin
+    m = TightBinding1D()
+    @test onsite_observable_op(m, :n) == "N"
+    @test onsite_observable_op(m, :c) == "C"
+    @test onsite_observable_op(m, :cdag) == "Cdag"
+    @test_throws ErrorException onsite_observable_op(m, :bogus)
+end
+
+@testset "TightBinding1D: build_opsum on Fermion sites" begin
+    N = 6
+    m = TightBinding1D(; t=1.0, μ=0.0)
+    sites = siteinds("Fermion", N)
+    H = build_opsum(m, sites; phys_sites=1:N, boundary=:full)
+    @test length(collect(ITensors.terms(H))) > 0
+end
+
+@testset "TightBinding1D: ModulatedModel wraps without error" begin
+    L = 6
+    m_ssd = modulated(TightBinding1D(; t=1.0, μ=0.5); L=L, modulation=SSD())
+    sites = siteinds("Fermion", L)
+    H = build_opsum(m_ssd, sites; phys_sites=1:L, boundary=:full)
+    @test length(collect(ITensors.terms(H))) > 0
+end
+
+@testset "TightBinding1D: DMRG GS energy matches analytic half-filling" begin
+    # Open-chain spectrum: ε_k = -2t cos(kπ/(N+1)), k ∈ 1..N.
+    # At μ = 0, half-filling fills the negative-ε states.
+    N = 8
+    t = 1.0
+    m = TightBinding1D(; t=t, μ=0.0)
+    sites = siteinds("Fermion", N)
+    H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
+
+    eps = [-2 * t * cos(k * π / (N + 1)) for k in 1:N]
+    E_exact = sum(filter(e -> e < 0, eps))
+
+    psi0 = random_mps(MersenneTwister(0xfe), sites; linkdims=16)
+    sweeps = Sweeps(20)
+    maxdim!(sweeps, 10, 20, 40, 80, 100, 120, 120, 120, 120, 120,
+        120, 120, 120, 120, 120, 120, 120, 120, 120, 120)
+    cutoff!(sweeps, 1e-12)
+    E_dmrg, _ = dmrg(H, psi0, sweeps; outputlevel=0)
+    @test E_dmrg ≈ E_exact rtol = 1e-5
+end

--- a/test/base/test_tightbinding_1d.jl
+++ b/test/base/test_tightbinding_1d.jl
@@ -71,8 +71,29 @@ end
 
     psi0 = random_mps(MersenneTwister(0xfe), sites; linkdims=16)
     sweeps = Sweeps(20)
-    maxdim!(sweeps, 10, 20, 40, 80, 100, 120, 120, 120, 120, 120,
-        120, 120, 120, 120, 120, 120, 120, 120, 120, 120)
+    maxdim!(
+        sweeps,
+        10,
+        20,
+        40,
+        80,
+        100,
+        120,
+        120,
+        120,
+        120,
+        120,
+        120,
+        120,
+        120,
+        120,
+        120,
+        120,
+        120,
+        120,
+        120,
+        120,
+    )
     cutoff!(sweeps, 1e-12)
     E_dmrg, _ = dmrg(H, psi0, sweeps; outputlevel=0)
     @test E_dmrg ≈ E_exact rtol = 1e-5


### PR DESCRIPTION
## Summary

1D spinless-fermion tight-binding chain on `SiteType("Fermion")`:

    H = -t Σ_i (c†_i c_{i+1} + c†_{i+1} c_i) + μ Σ_i n_i

First fermionic model in the package. Jordan-Wigner strings handled automatically by ITensors' OpSum → MPO conversion. Same split-protocol pattern as TFIM / TFIML.

## Test plan

- Pkg.test() green (733/733 passing, +7 new tests).
- Construction, bond_coupling_term hopping-only, onsite_term carries full μ, observable lookup.
- ModulatedModel wrapping smoke test.
- DMRG vs analytic on N=8 OBC half-filling: spectrum ε_k = -2t cos(kπ/(N+1)), DMRG GS matches sum of negative ε's to rtol=1e-5.

## Versioning

Bump 0.6.8 → 0.7.0 (minor: new public model). Parallel to #39 (S1Heisenberg1D); whichever lands first gets 0.7.0, the other rebases to 0.7.1.

## Follow-ups

- QAtlas 1D tight-binding does not exist; bridge is intentionally deferred.
- 2D LatticeModel + TightBinding bond → QAtlas.Honeycomb/Kagome/Lieb/Triangular bridge: future PR.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
