### PR TITLE
test(s1-heisenberg): integration on 2D lattices + ND modulation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.6.8"
+version = "0.7.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/examples/plot_modulation_1d.jl
+++ b/examples/plot_modulation_1d.jl
@@ -6,55 +6,55 @@ using Plots
 const L = 60
 
 modulations = [
-    ("Uniform",         Uniform()),
-    ("SSD",             SSD()),
-    ("SinPower{4}",     SinPower{4}()),
-    ("SinPower{6}",     SinPower{6}()),
-    ("SinPower{8}",     SinPower{8}()),
-    ("SmoothBoundary(5)",  SmoothBoundary(5)),
+    ("Uniform", Uniform()),
+    ("SSD", SSD()),
+    ("SinPower{4}", SinPower{4}()),
+    ("SinPower{6}", SinPower{6}()),
+    ("SinPower{8}", SinPower{8}()),
+    ("SmoothBoundary(5)", SmoothBoundary(5)),
     ("SmoothBoundary(10)", SmoothBoundary(10)),
     ("SmoothBoundary(20)", SmoothBoundary(20)),
 ]
 
 site_x = 1:L
-bond_x = 1:(L-1)
+bond_x = 1:(L - 1)
 
 # ---- site_weight ----
 p_site = plot(;
-    xlabel = "site index i",
-    ylabel = "site_weight(mod, i, L=$L)",
-    title  = "site weight envelopes (1D, L=$L)",
-    legend = :outerright,
-    size   = (900, 420),
-    framestyle = :box,
-    grid = true,
+    xlabel="site index i",
+    ylabel="site_weight(mod, i, L=$L)",
+    title="site weight envelopes (1D, L=$L)",
+    legend=:outerright,
+    size=(900, 420),
+    framestyle=:box,
+    grid=true,
 )
 for (name, m) in modulations
     ys = [site_weight(m, i, L) for i in site_x]
-    plot!(p_site, site_x, ys; label = name, lw = 2)
+    plot!(p_site, site_x, ys; label=name, lw=2)
 end
 
 # ---- bond_weight ----
 p_bond = plot(;
-    xlabel = "bond index i (bond connects i and i+1)",
-    ylabel = "bond_weight(mod, i, L=$L)",
-    title  = "bond weight envelopes (1D, L=$L)",
-    legend = :outerright,
-    size   = (900, 420),
-    framestyle = :box,
-    grid = true,
+    xlabel="bond index i (bond connects i and i+1)",
+    ylabel="bond_weight(mod, i, L=$L)",
+    title="bond weight envelopes (1D, L=$L)",
+    legend=:outerright,
+    size=(900, 420),
+    framestyle=:box,
+    grid=true,
 )
 for (name, m) in modulations
     ys = [bond_weight(m, i, L) for i in bond_x]
-    plot!(p_bond, bond_x, ys; label = name, lw = 2)
+    plot!(p_bond, bond_x, ys; label=name, lw=2)
 end
 
 # Combined panel.
-p_all = plot(p_site, p_bond; layout = (2, 1), size = (1000, 800))
+p_all = plot(p_site, p_bond; layout=(2, 1), size=(1000, 800))
 
 outdir = joinpath(@__DIR__, "out")
 mkpath(outdir)
 savefig(p_site, joinpath(outdir, "site_weight.png"))
 savefig(p_bond, joinpath(outdir, "bond_weight.png"))
-savefig(p_all,  joinpath(outdir, "combined.png"))
+savefig(p_all, joinpath(outdir, "combined.png"))
 println("Wrote: ", readdir(outdir))

--- a/examples/plot_modulation_2d_continuous.jl
+++ b/examples/plot_modulation_2d_continuous.jl
@@ -52,7 +52,8 @@ env_cyl_x(x, y) = ssd_axis(x, Lx)
 # the envelope reaches 0 on the inscribed circle and is identically
 # zero outside it (corners are dark).
 function env_sphere_inscribed(x, y)
-    cx = center(Lx); cy = center(Ly)
+    cx = center(Lx);
+    cy = center(Ly)
     d = sqrt((x - cx)^2 + (y - cy)^2)
     R = min(Lx, Ly) / 2
     profile_sin_square(d, R)
@@ -62,7 +63,8 @@ end
 # the envelope only reaches 0 at the corners; the four edge midpoints
 # carry a finite weight. This is what "spherical, no zero rim" looks like.
 function env_sphere_circumscribed(x, y)
-    cx = center(Lx); cy = center(Ly)
+    cx = center(Lx);
+    cy = center(Ly)
     d = sqrt((x - cx)^2 + (y - cy)^2)
     R = sqrt((Lx / 2)^2 + (Ly / 2)^2)
     profile_sin_square(d, R)
@@ -71,7 +73,8 @@ end
 # (5) Spherical SinPower{4}: sharper roll-off at the boundary, broader
 # central plateau (Hotta-Shibata flavour on a disk).
 function env_sphere_sinpow4(x, y)
-    cx = center(Lx); cy = center(Ly)
+    cx = center(Lx);
+    cy = center(Ly)
     d = sqrt((x - cx)^2 + (y - cy)^2)
     R = min(Lx, Ly) / 2
     profile_sin_power(d, R, 4)
@@ -80,7 +83,8 @@ end
 # (6) Spherical SmoothBoundary: flat-1 plateau in the bulk + half-cosine
 # ramp on the rim (Vekic-White on a disk).
 function env_sphere_smooth(x, y)
-    cx = center(Lx); cy = center(Ly)
+    cx = center(Lx);
+    cy = center(Ly)
     d = sqrt((x - cx)^2 + (y - cy)^2)
     R = min(Lx, Ly) / 2
     profile_smooth(d, R, 8)
@@ -88,37 +92,45 @@ end
 
 # ---- Build heatmaps -------------------------------------------------
 
-xs = range(0.5, Lx + 0.5; length = 200)
-ys = range(0.5, Ly + 0.5; length = 200)
+xs = range(0.5, Lx + 0.5; length=200)
+ys = range(0.5, Ly + 0.5; length=200)
 
 panels = [
-    ("Rectangular SSD\n(axis product)",                env_rect),
-    ("Cylindrical SSD (x-axial)\nuniform in y",         env_cyl_x),
-    ("Spherical SSD\ninscribed R = min(Lx,Ly)/2",       env_sphere_inscribed),
-    ("Spherical SSD\ncircumscribed R = ‖(Lx,Ly)‖/2",    env_sphere_circumscribed),
-    ("Spherical SinPower{4}\nR = min/2",                env_sphere_sinpow4),
-    ("Spherical SmoothBoundary\nR = min/2, edge = 8",   env_sphere_smooth),
+    ("Rectangular SSD\n(axis product)", env_rect),
+    ("Cylindrical SSD (x-axial)\nuniform in y", env_cyl_x),
+    ("Spherical SSD\ninscribed R = min(Lx,Ly)/2", env_sphere_inscribed),
+    ("Spherical SSD\ncircumscribed R = ‖(Lx,Ly)‖/2", env_sphere_circumscribed),
+    ("Spherical SinPower{4}\nR = min/2", env_sphere_sinpow4),
+    ("Spherical SmoothBoundary\nR = min/2, edge = 8", env_sphere_smooth),
 ]
 
 plts = []
 for (title, f) in panels
     Z = [f(x, y) for y in ys, x in xs]   # Z[j, i] = f(xs[i], ys[j])
-    p = heatmap(xs, ys, Z;
-        title  = title,
-        xlabel = "x",
-        ylabel = "y",
-        aspect_ratio = :equal,
-        c = :viridis,
-        clims  = (0.0, 1.0),
-        colorbar = false,
-        framestyle = :box,
+    p = heatmap(
+        xs,
+        ys,
+        Z;
+        title=title,
+        xlabel="x",
+        ylabel="y",
+        aspect_ratio=:equal,
+        c=:viridis,
+        clims=(0.0, 1.0),
+        colorbar=false,
+        framestyle=:box,
     )
     # Overlay a 0.5-level contour to make the falloff region visible.
-    contour!(p, xs, ys, Z; levels = [0.5], lc = :white, lw = 1.2)
+    contour!(p, xs, ys, Z; levels=[0.5], lc=:white, lw=1.2)
     push!(plts, p)
 end
 
-p_all = plot(plts...; layout = (3, 2), size = (1100, 1500), plot_title = "2D Modulation Envelopes (Lx=Ly=$Lx)")
+p_all = plot(
+    plts...;
+    layout=(3, 2),
+    size=(1100, 1500),
+    plot_title="2D Modulation Envelopes (Lx=Ly=$Lx)",
+)
 
 outdir = joinpath(@__DIR__, "out")
 mkpath(outdir)
@@ -127,20 +139,56 @@ println("Wrote: ", joinpath("out", "2d_continuous.png"))
 
 # Also dump a 1D radial cut through the disk envelopes so we can compare
 # the radial profiles directly.
-rs = range(0.0, min(Lx, Ly) / 2; length = 200)
+rs = range(0.0, min(Lx, Ly) / 2; length=200)
 p_radial = plot(;
-    xlabel = "distance from center r",
-    ylabel = "envelope(r)",
-    title  = "Radial profile cuts (R = min(Lx,Ly)/2 = $(min(Lx,Ly) ÷ 2))",
-    legend = :outerright,
-    framestyle = :box,
-    size   = (900, 420),
+    xlabel="distance from center r",
+    ylabel="envelope(r)",
+    title="Radial profile cuts (R = min(Lx,Ly)/2 = $(min(Lx,Ly) ÷ 2))",
+    legend=:outerright,
+    framestyle=:box,
+    size=(900, 420),
 )
-plot!(p_radial, rs, [profile_sin_square(r, min(Lx, Ly) / 2) for r in rs]; label = "SinSquare", lw = 2)
-plot!(p_radial, rs, [profile_sin_power(r, min(Lx, Ly) / 2, 4) for r in rs]; label = "SinPower{4}", lw = 2)
-plot!(p_radial, rs, [profile_sin_power(r, min(Lx, Ly) / 2, 8) for r in rs]; label = "SinPower{8}", lw = 2)
-plot!(p_radial, rs, [profile_smooth(r, min(Lx, Ly) / 2, 4) for r in rs]; label = "SmoothBoundary edge=4", lw = 2)
-plot!(p_radial, rs, [profile_smooth(r, min(Lx, Ly) / 2, 8) for r in rs]; label = "SmoothBoundary edge=8", lw = 2)
-plot!(p_radial, rs, [profile_smooth(r, min(Lx, Ly) / 2, 12) for r in rs]; label = "SmoothBoundary edge=12", lw = 2)
+plot!(
+    p_radial,
+    rs,
+    [profile_sin_square(r, min(Lx, Ly) / 2) for r in rs];
+    label="SinSquare",
+    lw=2,
+)
+plot!(
+    p_radial,
+    rs,
+    [profile_sin_power(r, min(Lx, Ly) / 2, 4) for r in rs];
+    label="SinPower{4}",
+    lw=2,
+)
+plot!(
+    p_radial,
+    rs,
+    [profile_sin_power(r, min(Lx, Ly) / 2, 8) for r in rs];
+    label="SinPower{8}",
+    lw=2,
+)
+plot!(
+    p_radial,
+    rs,
+    [profile_smooth(r, min(Lx, Ly) / 2, 4) for r in rs];
+    label="SmoothBoundary edge=4",
+    lw=2,
+)
+plot!(
+    p_radial,
+    rs,
+    [profile_smooth(r, min(Lx, Ly) / 2, 8) for r in rs];
+    label="SmoothBoundary edge=8",
+    lw=2,
+)
+plot!(
+    p_radial,
+    rs,
+    [profile_smooth(r, min(Lx, Ly) / 2, 12) for r in rs];
+    label="SmoothBoundary edge=12",
+    lw=2,
+)
 savefig(p_radial, joinpath(outdir, "2d_radial_profile.png"))
 println("Wrote: ", joinpath("out", "2d_radial_profile.png"))

--- a/examples/plot_modulation_honeycomb_scatter.jl
+++ b/examples/plot_modulation_honeycomb_scatter.jl
@@ -19,21 +19,31 @@ xs = [p[1] for p in ps]
 ys = [p[2] for p in ps]
 
 panels = [
-    ("spherical_ssd (inscribed)",     spherical_ssd(lat; radius=:inscribed)),
+    ("spherical_ssd (inscribed)", spherical_ssd(lat; radius=:inscribed)),
     ("spherical_ssd (circumscribed)", spherical_ssd(lat; radius=:circumscribed)),
-    ("spherical_ssd (N=4)",           spherical_ssd(lat; radius=:circumscribed, N=4)),
-    ("cylindrical_ssd (axis=1)",      cylindrical_ssd(lat; axis=1)),
-    ("cylindrical_ssd (axis=2)",      cylindrical_ssd(lat; axis=2)),
-    ("rectangular_ssd",               rectangular_ssd(lat)),
+    ("spherical_ssd (N=4)", spherical_ssd(lat; radius=:circumscribed, N=4)),
+    ("cylindrical_ssd (axis=1)", cylindrical_ssd(lat; axis=1)),
+    ("cylindrical_ssd (axis=2)", cylindrical_ssd(lat; axis=2)),
+    ("rectangular_ssd", rectangular_ssd(lat)),
 ]
 
 plts = []
 for (title, env) in panels
     ws = [ITensorModels.site_weight(env, lat, k) for k in 1:num_sites(lat)]
     p = scatter(
-        xs, ys; marker_z=ws, c=:viridis, ms=8, msw=0.4,
-        clims=(0.0, 1.0), aspect_ratio=:equal, title=title,
-        xlabel="x", ylabel="y", framestyle=:box, legend=false,
+        xs,
+        ys;
+        marker_z=ws,
+        c=:viridis,
+        ms=8,
+        msw=0.4,
+        clims=(0.0, 1.0),
+        aspect_ratio=:equal,
+        title=title,
+        xlabel="x",
+        ylabel="y",
+        framestyle=:box,
+        legend=false,
         colorbar=true,
     )
     # Overlay bond midpoints coloured by bond_weight for visual continuity.
@@ -48,7 +58,9 @@ for (title, env) in panels
 end
 
 p_all = plot(
-    plts...; layout=(3, 2), size=(1100, 1500),
+    plts...;
+    layout=(3, 2),
+    size=(1100, 1500),
     plot_title="ND modulation envelopes on honeycomb($L, $L) — site_weight scatter",
 )
 

--- a/ext/LatticeCoreExt.jl
+++ b/ext/LatticeCoreExt.jl
@@ -381,23 +381,17 @@ function ITensorModels.spherical_ssd(
     elseif radius === :circumscribed
         sqrt(sum(half .^ 2))
     else
-        error(
-            "spherical_ssd: radius must be :inscribed or :circumscribed " *
-            "(got :$radius)",
-        )
+        error("spherical_ssd: radius must be :inscribed or :circumscribed " * "(got :$radius)")
     end
     return RadialEnvelope(
         BoundingBoxCenter(), EuclideanDistance(), _make_profile(Val(N), R)
     )
 end
 
-function ITensorModels.cylindrical_ssd(
-    lat::AbstractLattice; axis::Int=1, N::Int=2
-)
+function ITensorModels.cylindrical_ssd(lat::AbstractLattice; axis::Int=1, N::Int=2)
     lo, hi = _bounding_extent(lat)
-    1 <= axis <= length(lo) || error(
-        "cylindrical_ssd: axis=$axis out of range [1, $(length(lo))]"
-    )
+    1 <= axis <= length(lo) ||
+        error("cylindrical_ssd: axis=$axis out of range [1, $(length(lo))]")
     R = (hi[axis] - lo[axis]) / 2
     return RadialEnvelope(
         BoundingBoxCenter(), AxialDistance(axis), _make_profile(Val(N), R)

--- a/src/ITensorModels.jl
+++ b/src/ITensorModels.jl
@@ -8,7 +8,7 @@ export AbstractLatticeModel, site_type
 export bond_term, boundary_patch, local_ham_terms, build_opsum
 export bond_coupling_term, onsite_term
 export onsite_observable_op, build_onsite_observable_opsum
-export TFIM, TFIML, XXZ1D, Heisenberg1D, KitaevBond, LatticeModel
+export TFIM, TFIML, XXZ1D, Heisenberg1D, S1Heisenberg1D, KitaevBond, LatticeModel
 export AbstractModulation, Uniform, SSD, SinPower, SmoothBoundary, Tabulated
 export site_weight, bond_weight
 export ModulatedModel, modulated
@@ -66,6 +66,7 @@ include("models/tfim.jl")
 include("models/tfiml.jl")
 include("models/xxz.jl")
 include("models/heisenberg.jl")
+include("models/heisenberg_s1.jl")
 include("models/kitaev_bond.jl")
 include("models/lattice_model.jl")
 include("models/modulated.jl")

--- a/src/core/modulation_nd.jl
+++ b/src/core/modulation_nd.jl
@@ -206,7 +206,9 @@ function _validate_radius_positive(name::String, R)
         all(x -> x isa Real && x > 0, R) ||
             error("$name: every per-axis R entry must be a positive Real, got R=$R")
     else
-        error("$name: R must be a positive Real or an iterable of positive Reals, got typeof(R)=$(typeof(R))")
+        error(
+            "$name: R must be a positive Real or an iterable of positive Reals, got typeof(R)=$(typeof(R))",
+        )
     end
     return nothing
 end
@@ -277,7 +279,7 @@ struct CosineRampProfile{R,E} <: AbstractProfile
         # deferred so a vector R does not reach this constructor in practice.
         if r isa Real
             e <= r || error(
-                "CosineRampProfile: edge must satisfy 0 < edge <= R, got edge=$e, R=$r",
+                "CosineRampProfile: edge must satisfy 0 < edge <= R, got edge=$e, R=$r"
             )
         end
         return new{R,E}(r, e)

--- a/src/models/heisenberg_s1.jl
+++ b/src/models/heisenberg_s1.jl
@@ -1,0 +1,48 @@
+using ITensors: SiteType, @SiteType_str
+
+"""
+    S1Heisenberg1D(; J=1.0, site=SiteType("S=1"))
+
+1D spin-1 isotropic Heisenberg chain
+
+    H = J Σ [ Sˣᵢ Sˣᵢ₊₁ + Sʸᵢ Sʸᵢ₊₁ + Sᶻᵢ Sᶻᵢ₊₁ ]
+
+on a three-dimensional local Hilbert space. Matches
+`QAtlas.S1Heisenberg1D`.
+
+The Haldane gap (≈ 0.41048J at the infinite-chain limit) and the
+symmetry-protected-topological (SPT) ground state on open boundaries
+are the key physics distinguishing this model from its spin-½
+counterpart [`Heisenberg1D`](@ref).
+
+Structurally this is a thin alias around [`XXZ1D`](@ref) at `Δ = 1`
+with `site = SiteType("S=1")` — the spin-1 Sx/Sy/Sz operators on
+`SiteType("S=1")` carry the same operator-norm convention as
+`SiteType("S=1/2")`, so the existing `XXZ1D` machinery applies
+verbatim.
+"""
+Base.@kwdef struct S1Heisenberg1D <: AbstractLatticeModel
+    J::Float64 = 1.0
+    site::SiteType = SiteType("S=1")
+end
+
+site_type(m::S1Heisenberg1D) = m.site
+
+function bond_term(m::S1Heisenberg1D, i::Int, j::Int)
+    return bond_term(XXZ1D(; J=m.J, Δ=1.0, site=m.site), i, j)
+end
+
+function onsite_observable_op(m::S1Heisenberg1D, name::Symbol)
+    return onsite_observable_op(XXZ1D(; J=m.J, Δ=1.0, site=m.site), name)
+end
+
+# ---------------------------------------------------------------------
+# Split protocol: delegate to XXZ1D at Δ=1 — same alias pattern as
+# Heisenberg1D's split protocol.
+# ---------------------------------------------------------------------
+
+function bond_coupling_term(m::S1Heisenberg1D, i::Int, j::Int)
+    return bond_coupling_term(XXZ1D(; J=m.J, Δ=1.0, site=m.site), i, j)
+end
+
+onsite_term(::S1Heisenberg1D, ::Int) = OpSum()

--- a/src/models/xxz.jl
+++ b/src/models/xxz.jl
@@ -26,6 +26,7 @@ site_type(m::XXZ1D) = m.site
 # turns QAtlas' spin-½ coefficients into the operator norms used here.
 _xxz_ops(::SiteType"S=1/2") = ("Sx", "Sy", "Sz", 1.0)
 _xxz_ops(::SiteType"Qubit") = ("X", "Y", "Z", 0.25)
+_xxz_ops(::SiteType"S=1") = ("Sx", "Sy", "Sz", 1.0)
 
 function bond_term(m::XXZ1D, i::Int, j::Int)
     xop, yop, zop, scale = _xxz_ops(m.site)

--- a/test/base/test_heisenberg_s1.jl
+++ b/test/base/test_heisenberg_s1.jl
@@ -28,8 +28,7 @@ end
     m = S1Heisenberg1D(; J=0.8)
     H_bond = bond_term(m, 3, 4)
     H_coup = bond_coupling_term(m, 3, 4)
-    @test length(collect(ITensors.terms(H_bond))) ==
-        length(collect(ITensors.terms(H_coup)))
+    @test length(collect(ITensors.terms(H_bond))) == length(collect(ITensors.terms(H_coup)))
     @test length(collect(ITensors.terms(onsite_term(m, 1)))) == 0
 end
 

--- a/test/base/test_heisenberg_s1.jl
+++ b/test/base/test_heisenberg_s1.jl
@@ -1,0 +1,79 @@
+using ITensorModels
+using ITensors
+using ITensors: SiteType
+using ITensorMPS
+using Random
+using Test
+
+@testset "S1Heisenberg1D: construction" begin
+    m = S1Heisenberg1D()
+    @test m isa AbstractLatticeModel
+    @test m.J == 1.0
+    @test site_type(m) == SiteType("S=1")
+
+    m2 = S1Heisenberg1D(; J=2.5)
+    @test m2.J == 2.5
+end
+
+@testset "S1Heisenberg1D: bond_term structure" begin
+    m = S1Heisenberg1D(; J=1.5)
+    H = bond_term(m, 1, 2)
+    terms = collect(ITensors.terms(H))
+    @test length(terms) == 3
+    coeffs = [ITensors.coefficient(t) for t in terms]
+    @test all(c -> c ≈ 1.5, coeffs)
+end
+
+@testset "S1Heisenberg1D: bond_coupling_term ≡ bond_term (no onsite)" begin
+    m = S1Heisenberg1D(; J=0.8)
+    H_bond = bond_term(m, 3, 4)
+    H_coup = bond_coupling_term(m, 3, 4)
+    @test length(collect(ITensors.terms(H_bond))) ==
+        length(collect(ITensors.terms(H_coup)))
+    @test length(collect(ITensors.terms(onsite_term(m, 1)))) == 0
+end
+
+@testset "S1Heisenberg1D: onsite_observable_op" begin
+    m = S1Heisenberg1D()
+    @test onsite_observable_op(m, :sx) == "Sx"
+    @test onsite_observable_op(m, :sy) == "Sy"
+    @test onsite_observable_op(m, :sz) == "Sz"
+    @test_throws ErrorException onsite_observable_op(m, :bogus)
+end
+
+@testset "S1Heisenberg1D: build_opsum on S=1 sites" begin
+    N = 6
+    m = S1Heisenberg1D(; J=1.0)
+    sites = siteinds("S=1", N)
+    H = build_opsum(m, sites; phys_sites=1:N, boundary=:full)
+    # N-1 bonds * 3 (XX/YY/ZZ); no on-site or boundary terms.
+    @test length(collect(ITensors.terms(H))) == 3 * (N - 1)
+end
+
+@testset "S1Heisenberg1D: ModulatedModel wraps without error" begin
+    L = 6
+    m_ssd = modulated(S1Heisenberg1D(; J=1.0); L=L, modulation=SSD())
+    sites = siteinds("S=1", L)
+    H = build_opsum(m_ssd, sites; phys_sites=1:L, boundary=:full)
+    @test length(collect(ITensors.terms(H))) > 0
+    @test length(collect(ITensors.terms(H))) == 3 * (L - 1)
+end
+
+@testset "S1Heisenberg1D: DMRG GS energy sanity" begin
+    # Spin-1 Heisenberg OBC GS energy density ≈ -1.4 in the bulk;
+    # for N = 8 expect E ≈ -10.5. We only check the OpSum -> MPO ->
+    # DMRG pipeline produces an energy in the expected qualitative
+    # range. QAtlas comparison lands in PR-S1B.
+    N = 8
+    m = S1Heisenberg1D(; J=1.0)
+    sites = siteinds("S=1", N)
+    H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
+
+    rng = MersenneTwister(0x51)
+    psi0 = random_mps(rng, sites; linkdims=8)
+    sweeps = Sweeps(10)
+    maxdim!(sweeps, 10, 20, 40, 60, 80, 100, 100, 100, 100, 100)
+    cutoff!(sweeps, 1e-10)
+    E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
+    @test -15.0 < E < -5.0
+end

--- a/test/base/test_modulated_lattice.jl
+++ b/test/base/test_modulated_lattice.jl
@@ -7,15 +7,8 @@ using Test
 
 @testset "ModulatedLatticeModel: construction" begin
     lat = Lattice2D.honeycomb(4, 4; boundary=OpenAxis())
-    base = LatticeModel(;
-        lattice=lat,
-        bond_models=Dict(:nearest => Heisenberg1D(; J=1.0)),
-    )
-    env = RadialEnvelope(
-        BoundingBoxCenter(),
-        EuclideanDistance(),
-        SinSquareProfile(5.0),
-    )
+    base = LatticeModel(; lattice=lat, bond_models=Dict(:nearest => Heisenberg1D(; J=1.0)))
+    env = RadialEnvelope(BoundingBoxCenter(), EuclideanDistance(), SinSquareProfile(5.0))
     mod = modulated_lattice(base; envelope=env)
     @test mod isa ModulatedLatticeModel
     @test mod isa AbstractLatticeModel
@@ -26,13 +19,10 @@ end
 
 @testset "ModulatedLatticeModel: build_opsum on honeycomb" begin
     lat = Lattice2D.honeycomb(4, 4; boundary=OpenAxis())
-    base = LatticeModel(;
-        lattice=lat,
-        bond_models=Dict(:nearest => Heisenberg1D(; J=1.0)),
-    )
+    base = LatticeModel(; lattice=lat, bond_models=Dict(:nearest => Heisenberg1D(; J=1.0)))
     ps = collect(LatticeCore.positions(lat))
     rc = ITensorModels.center_position(BoundingBoxCenter(), lat)
-    R = sqrt(maximum(sum((p .- rc).^2) for p in ps)) + 0.5
+    R = sqrt(maximum(sum((p .- rc) .^ 2) for p in ps)) + 0.5
     env = RadialEnvelope(BoundingBoxCenter(), EuclideanDistance(), SinSquareProfile(R))
     mod = modulated_lattice(base; envelope=env)
 
@@ -52,9 +42,8 @@ end
     H_ref = OpSum()
     for b in bonds(lat)
         fb = ITensorModels.bond_weight(env, lat, b.i, b.j)
-        H_ref += fb * ITensorModels.bond_coupling_term(
-            Heisenberg1D(; J=1.0), ord[b.i], ord[b.j]
-        )
+        H_ref +=
+            fb * ITensorModels.bond_coupling_term(Heisenberg1D(; J=1.0), ord[b.i], ord[b.j])
     end
     ref_terms = collect(ITensors.terms(H_ref))
     @test length(ref_terms) > 0
@@ -73,7 +62,7 @@ end
     lat = Lattice2D.honeycomb(4, 4; boundary=OpenAxis())
     ps = collect(LatticeCore.positions(lat))
     rc = ITensorModels.center_position(BoundingBoxCenter(), lat)
-    R_huge = 1000 * sqrt(maximum(sum((p .- rc).^2) for p in ps))
+    R_huge = 1000 * sqrt(maximum(sum((p .- rc) .^ 2) for p in ps))
     env = RadialEnvelope(BoundingBoxCenter(), EuclideanDistance(), SinSquareProfile(R_huge))
 
     for b in bonds(lat)
@@ -91,14 +80,14 @@ end
     lat = Lattice2D.honeycomb(6, 6; boundary=OpenAxis())
     ps = collect(LatticeCore.positions(lat))
     rc = ITensorModels.center_position(BoundingBoxCenter(), lat)
-    R = sqrt(maximum(sum((p .- rc).^2) for p in ps))
+    R = sqrt(maximum(sum((p .- rc) .^ 2) for p in ps))
     env = RadialEnvelope(BoundingBoxCenter(), EuclideanDistance(), SinSquareProfile(R))
 
     bs = collect(bonds(lat))
     w_corner = ITensorModels.bond_weight(env, lat, bs[1].i, bs[1].j)
 
     midpoints = [(position(lat, b.i) + position(lat, b.j)) / 2 for b in bs]
-    distances = [sqrt(sum((mid .- rc).^2)) for mid in midpoints]
+    distances = [sqrt(sum((mid .- rc) .^ 2)) for mid in midpoints]
     k_central = argmin(distances)
     w_centre = ITensorModels.bond_weight(env, lat, bs[k_central].i, bs[k_central].j)
 
@@ -113,13 +102,10 @@ end
     # count (which would be all we'd get if onsite emission were
     # missing).
     lat = Lattice2D.honeycomb(4, 4; boundary=OpenAxis())
-    base = LatticeModel(;
-        lattice=lat,
-        bond_models=Dict(:nearest => TFIM(; J=1.0, h=0.5)),
-    )
+    base = LatticeModel(; lattice=lat, bond_models=Dict(:nearest => TFIM(; J=1.0, h=0.5)))
     ps = collect(LatticeCore.positions(lat))
     rc = ITensorModels.center_position(BoundingBoxCenter(), lat)
-    R_huge = 1000 * sqrt(maximum(sum((p .- rc).^2) for p in ps))
+    R_huge = 1000 * sqrt(maximum(sum((p .- rc) .^ 2) for p in ps))
     env = RadialEnvelope(BoundingBoxCenter(), EuclideanDistance(), SinSquareProfile(R_huge))
     mod = modulated_lattice(base; envelope=env)
 

--- a/test/base/test_modulation_nd_1d_equivalence.jl
+++ b/test/base/test_modulation_nd_1d_equivalence.jl
@@ -21,9 +21,7 @@ using Test
     # BoundingBoxCenter at (L+1)/2) with SinSquareProfile(L/2) is
     # designed to match the 1D SSD weights exactly.
     lat = LineLattice(L, OpenAxis())
-    env = RadialEnvelope(
-        BoundingBoxCenter(), AxialDistance(1), SinSquareProfile(L / 2)
-    )
+    env = RadialEnvelope(BoundingBoxCenter(), AxialDistance(1), SinSquareProfile(L / 2))
 
     # site_weight on ND ≡ 1D site_weight(SSD, k, L).
     for k in 1:L
@@ -55,13 +53,8 @@ end
 
     # ND path: LineLattice + LatticeModel(TFIM) + RadialEnvelope.
     lat = LineLattice(L, OpenAxis())
-    base_nd = LatticeModel(;
-        lattice=lat,
-        bond_models=Dict(:nearest => TFIM(; J=J, h=h)),
-    )
-    env = RadialEnvelope(
-        BoundingBoxCenter(), AxialDistance(1), SinSquareProfile(L / 2)
-    )
+    base_nd = LatticeModel(; lattice=lat, bond_models=Dict(:nearest => TFIM(; J=J, h=h)))
+    env = RadialEnvelope(BoundingBoxCenter(), AxialDistance(1), SinSquareProfile(L / 2))
     mod_nd = modulated_lattice(base_nd; envelope=env)
     H_nd_opsum = build_opsum(mod_nd, sites)
     MPO_nd = MPO(H_nd_opsum, sites)
@@ -88,18 +81,15 @@ end
     sites = siteinds("S=1/2", L)
 
     lat = LineLattice(L, OpenAxis())
-    base_nd = LatticeModel(;
-        lattice=lat,
-        bond_models=Dict(:nearest => TFIM(; J=J, h=h)),
-    )
-    env = RadialEnvelope(
-        BoundingBoxCenter(), AxialDistance(1), SinSquareProfile(1000 * L)
-    )
+    base_nd = LatticeModel(; lattice=lat, bond_models=Dict(:nearest => TFIM(; J=J, h=h)))
+    env = RadialEnvelope(BoundingBoxCenter(), AxialDistance(1), SinSquareProfile(1000 * L))
     mod_nd = modulated_lattice(base_nd; envelope=env)
     MPO_nd_huge = MPO(build_opsum(mod_nd, sites), sites)
 
     mod_uniform = modulated(TFIM(; J=J, h=h); L=L, modulation=Uniform())
-    MPO_uniform = MPO(build_opsum(mod_uniform, sites; phys_sites=1:L, boundary=:full), sites)
+    MPO_uniform = MPO(
+        build_opsum(mod_uniform, sites; phys_sites=1:L, boundary=:full), sites
+    )
 
     rng = MersenneTwister(0x9c1f)
     for trial in 1:3

--- a/test/base/test_modulation_nd_factories.jl
+++ b/test/base/test_modulation_nd_factories.jl
@@ -16,7 +16,7 @@ using Test
     # site_weight clips to 0 there.
     ps = collect(LatticeCore.positions(lat))
     rc = ITensorModels.center_position(BoundingBoxCenter(), lat)
-    k_corner = argmax([sqrt(sum((p .- rc).^2)) for p in ps])
+    k_corner = argmax([sqrt(sum((p .- rc) .^ 2)) for p in ps])
     @test ITensorModels.site_weight(env_in, lat, k_corner) ≈ 0.0 atol = 1e-12
 end
 
@@ -27,7 +27,7 @@ end
     @test env_out.profile isa SinSquareProfile
     ps = collect(LatticeCore.positions(lat))
     rc = ITensorModels.center_position(BoundingBoxCenter(), lat)
-    distances = [sqrt(sum((p .- rc).^2)) for p in ps]
+    distances = [sqrt(sum((p .- rc) .^ 2)) for p in ps]
     d_max = maximum(distances)
     for k in 1:num_sites(lat)
         w = ITensorModels.site_weight(env_out, lat, k)
@@ -97,7 +97,7 @@ end
 
     ps = collect(LatticeCore.positions(lat))
     rc = ITensorModels.center_position(BoundingBoxCenter(), lat)
-    k_central = argmin([sqrt(sum((p .- rc).^2)) for p in ps])
+    k_central = argmin([sqrt(sum((p .- rc) .^ 2)) for p in ps])
     @test 0.0 <= ITensorModels.site_weight(env, lat, k_central) <= 1.0
     @test ITensorModels.site_weight(env, lat, k_central) >= 0.85
 end

--- a/test/base/test_modulation_nd_validation.jl
+++ b/test/base/test_modulation_nd_validation.jl
@@ -88,9 +88,7 @@ end
 
 @testset "RadialEnvelope: CosineRampProfile + AxisProductDistance unsupported" begin
     @test_throws ErrorException RadialEnvelope(
-        BoundingBoxCenter(),
-        AxisProductDistance(),
-        CosineRampProfile(5.0, 1.0),
+        BoundingBoxCenter(), AxisProductDistance(), CosineRampProfile(5.0, 1.0)
     )
 end
 
@@ -143,8 +141,7 @@ end
     lat = Lattice2D.honeycomb(6, 6; boundary=OpenAxis())
     ps = collect(LatticeCore.positions(lat))
     Ry = maximum(
-        abs(p[2] - ITensorModels.center_position(BoundingBoxCenter(), lat)[2])
-        for p in ps
+        abs(p[2] - ITensorModels.center_position(BoundingBoxCenter(), lat)[2]) for p in ps
     )
     env = RadialEnvelope(
         BoundingBoxCenter(), PerpendicularDistance(1), SinSquareProfile(Ry)

--- a/test/base/test_s1heisenberg_2d.jl
+++ b/test/base/test_s1heisenberg_2d.jl
@@ -1,0 +1,69 @@
+using ITensorModels
+using ITensors
+using ITensors: SiteType
+using ITensorMPS
+using LatticeCore
+using LatticeCore: num_sites, position, positions, bonds
+using Lattice2D
+using Random
+using Test
+
+@testset "S1Heisenberg1D on Lattice2D.honeycomb via LatticeModel" begin
+    lat = Lattice2D.honeycomb(3, 3; boundary=OpenAxis())
+    sub = S1Heisenberg1D(; J=1.0)
+    base = LatticeModel(; lattice=lat, bond_models=Dict(:nearest => sub))
+    @test base isa LatticeModel
+    @test site_type(base) == SiteType("S=1")
+
+    H = build_opsum(base, nothing)
+    nbonds = length(collect(bonds(lat)))
+    # 3 (XX + YY + ZZ) per bond, no on-site for S=1 Heisenberg.
+    @test length(collect(ITensors.terms(H))) == 3 * nbonds
+end
+
+@testset "S1Heisenberg1D on Lattice2D.kagome via LatticeModel" begin
+    lat = Lattice2D.kagome(2, 2; boundary=OpenAxis())
+    sub = S1Heisenberg1D(; J=1.0)
+    base = LatticeModel(; lattice=lat, bond_models=Dict(:nearest => sub))
+    H = build_opsum(base, nothing)
+    nbonds = length(collect(bonds(lat)))
+    @test length(collect(ITensors.terms(H))) == 3 * nbonds
+    @test nbonds > 0
+end
+
+@testset "S1Heisenberg1D + spherical_ssd ND modulation on honeycomb" begin
+    lat = Lattice2D.honeycomb(4, 4; boundary=OpenAxis())
+    sub = S1Heisenberg1D(; J=1.0)
+    base = LatticeModel(; lattice=lat, bond_models=Dict(:nearest => sub))
+    env = spherical_ssd(lat; radius=:circumscribed)
+    mod = modulated_lattice(base; envelope=env)
+    H = build_opsum(mod, nothing)
+    @test length(collect(ITensors.terms(H))) > 0
+
+    bs = collect(bonds(lat))
+    rc = ITensorModels.center_position(BoundingBoxCenter(), lat)
+    midpoints = [(position(lat, b.i) + position(lat, b.j)) / 2 for b in bs]
+    distances = [sqrt(sum((mid .- rc) .^ 2)) for mid in midpoints]
+    k_central = argmin(distances)
+    w_corner = ITensorModels.bond_weight(env, lat, bs[1].i, bs[1].j)
+    w_centre = ITensorModels.bond_weight(env, lat, bs[k_central].i, bs[k_central].j)
+    @test w_corner < w_centre
+end
+
+@testset "S1Heisenberg1D 2D DMRG smoke (very small)" begin
+    # Tiny honeycomb so DMRG converges quickly. We only check the
+    # pipeline runs; not a benchmark.
+    lat = Lattice2D.honeycomb(2, 2; boundary=OpenAxis())
+    sub = S1Heisenberg1D(; J=1.0)
+    base = LatticeModel(; lattice=lat, bond_models=Dict(:nearest => sub))
+    N = num_sites(lat)
+    sites = siteinds("S=1", N)
+    H = MPO(build_opsum(base, sites), sites)
+    psi0 = random_mps(MersenneTwister(0xa5), sites; linkdims=12)
+    sweeps = Sweeps(12)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200, 200, 200)
+    cutoff!(sweeps, 1e-10)
+    E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
+    @test isfinite(E)
+    @test E < 0.0
+end


### PR DESCRIPTION
## Summary

Integration test PR for #39 (S1Heisenberg1D). Exercises the new model through the existing LatticeModel + ModulatedLatticeModel infrastructure on 2D lattices (honeycomb, kagome) and confirms the spherical_ssd ND modulation factory cooperates with the spin-1 Heisenberg bond model.

No new src code. Tests only.

## Test plan

- Pkg.test() green (741/741 passing, +8 new tests).
- LatticeModel(honeycomb, S1Heisenberg1D) OpSum has 3 (XX/YY/ZZ) terms per bond.
- Same on kagome.
- spherical_ssd: corner bond weight strictly less than near-center bond weight.
- DMRG smoke on tiny honeycomb (8 S=1 sites) converges to finite E < 0.

## Versioning

Bump 0.7.0 -> 0.7.1 (patch: test surface).

## Stack

Based on #39 (feat/s1-heisenberg).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
