### PR TITLE
feat(models): add Hubbard1D (single-band Fermi-Hubbard chain)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/ITensorModels.jl
+++ b/src/ITensorModels.jl
@@ -13,6 +13,7 @@ export XYh1D
 export LongRangeIsing1D
 export ExtendedHubbard1D
 export Compass1D
+export Hubbard1D
 export TFIM, TFIML, XXZ1D, Heisenberg1D, S1Heisenberg1D, KitaevBond, LatticeModel
 export TFIM, TFIML, XXZ1D, Heisenberg1D, KitaevBond, TightBinding1D, LatticeModel
 export AbstractModulation, Uniform, SSD, SinPower, SmoothBoundary, Tabulated
@@ -73,6 +74,7 @@ include("models/tfiml.jl")
 include("models/xxz.jl")
 include("models/heisenberg.jl")
 include("models/heisenberg_s1.jl")
+include("models/hubbard_1d.jl")
 include("models/kitaev_bond.jl")
 include("models/xy_h_1d.jl")
 include("models/long_range_ising_1d.jl")

--- a/src/models/hubbard_1d.jl
+++ b/src/models/hubbard_1d.jl
@@ -1,0 +1,77 @@
+using ITensors: SiteType, @SiteType_str
+
+"""
+    Hubbard1D(; t=1.0, U=4.0, μ=0.0, site=SiteType("Electron"))
+
+1D single-band Fermi-Hubbard model
+
+    H = -t Σ_{i,σ} (c†_{i,σ} c_{i+1,σ} + h.c.)
+      + U Σ_i n_{i↑} n_{i↓}
+      + μ Σ_i (n_{i↑} + n_{i↓})
+
+on `SiteType("Electron")` sites (4-dim local Hilbert space:
+|0⟩, |↑⟩, |↓⟩, |↑↓⟩). Jordan-Wigner strings between non-adjacent
+fermion operators are inserted automatically by ITensors' OpSum →
+MPO conversion.
+
+Strong-coupling limit `U/t → ∞` at half-filling reduces to the
+Heisenberg spin chain (super-exchange J = 4t²/U); weak-coupling
+limit is two decoupled free-fermion chains. The 1D Hubbard model is
+exactly solvable by Bethe ansatz (Lieb–Wu 1968).
+"""
+Base.@kwdef struct Hubbard1D <: AbstractLatticeModel
+    t::Float64 = 1.0
+    U::Float64 = 4.0
+    μ::Float64 = 0.0
+    site::SiteType = SiteType("Electron")
+end
+
+site_type(m::Hubbard1D) = m.site
+
+function bond_term(m::Hubbard1D, i::Int, j::Int)
+    H = OpSum()
+    H += -m.t, "Cdagup", i, "Cup", j
+    H += -m.t, "Cdagup", j, "Cup", i
+    H += -m.t, "Cdagdn", i, "Cdn", j
+    H += -m.t, "Cdagdn", j, "Cdn", i
+    for k in (i, j)
+        H += (m.U / 2), "Nupdn", k
+        H += (m.μ / 2), "Nup", k
+        H += (m.μ / 2), "Ndn", k
+    end
+    return H
+end
+
+function boundary_patch(m::Hubbard1D, k::Int)
+    H = OpSum()
+    H += (m.U / 2), "Nupdn", k
+    H += (m.μ / 2), "Nup", k
+    H += (m.μ / 2), "Ndn", k
+    return H
+end
+
+function onsite_observable_op(m::Hubbard1D, name::Symbol)
+    name === :nup && return "Nup"
+    name === :ndn && return "Ndn"
+    name === :n && return "Ntot"
+    name === :nupdn && return "Nupdn"
+    name === :sz && return "Sz"
+    return error("Hubbard1D: unsupported onsite observable $name")
+end
+
+function bond_coupling_term(m::Hubbard1D, i::Int, j::Int)
+    H = OpSum()
+    H += -m.t, "Cdagup", i, "Cup", j
+    H += -m.t, "Cdagup", j, "Cup", i
+    H += -m.t, "Cdagdn", i, "Cdn", j
+    H += -m.t, "Cdagdn", j, "Cdn", i
+    return H
+end
+
+function onsite_term(m::Hubbard1D, k::Int)
+    H = OpSum()
+    H += m.U, "Nupdn", k
+    H += m.μ, "Nup", k
+    H += m.μ, "Ndn", k
+    return H
+end

--- a/test/base/test_hubbard_1d.jl
+++ b/test/base/test_hubbard_1d.jl
@@ -64,8 +64,7 @@ end
     H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
     psi0 = random_mps(MersenneTwister(0x1c), sites; linkdims=16)
     sweeps = Sweeps(15)
-    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
-        200, 200, 200, 200, 200)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200)
     cutoff!(sweeps, 1e-12)
     E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
     @test isfinite(E)

--- a/test/base/test_hubbard_1d.jl
+++ b/test/base/test_hubbard_1d.jl
@@ -1,0 +1,72 @@
+using ITensorModels
+using ITensors
+using ITensors: SiteType
+using ITensorMPS
+using Random
+using Test
+
+@testset "Hubbard1D: construction" begin
+    m = Hubbard1D()
+    @test m isa AbstractLatticeModel
+    @test m.t == 1.0
+    @test m.U == 4.0
+    @test m.μ == 0.0
+    @test site_type(m) == SiteType("Electron")
+end
+
+@testset "Hubbard1D: bond_coupling_term has 4 hoppings" begin
+    m = Hubbard1D(; t=2.0)
+    H = bond_coupling_term(m, 1, 2)
+    terms = collect(ITensors.terms(H))
+    @test length(terms) == 4
+    @test all(t -> ITensors.coefficient(t) ≈ -2.0, terms)
+end
+
+@testset "Hubbard1D: onsite_term carries U + 2μ" begin
+    m = Hubbard1D(; t=1.0, U=3.5, μ=0.7)
+    H = onsite_term(m, 1)
+    terms = collect(ITensors.terms(H))
+    @test length(terms) == 3
+end
+
+@testset "Hubbard1D: onsite_observable_op" begin
+    m = Hubbard1D()
+    @test onsite_observable_op(m, :nup) == "Nup"
+    @test onsite_observable_op(m, :ndn) == "Ndn"
+    @test onsite_observable_op(m, :n) == "Ntot"
+    @test onsite_observable_op(m, :nupdn) == "Nupdn"
+    @test onsite_observable_op(m, :sz) == "Sz"
+    @test_throws ErrorException onsite_observable_op(m, :bogus)
+end
+
+@testset "Hubbard1D: build_opsum on Electron sites" begin
+    N = 4
+    m = Hubbard1D(; t=1.0, U=4.0, μ=-2.0)
+    sites = siteinds("Electron", N)
+    H = build_opsum(m, sites; phys_sites=1:N, boundary=:full)
+    @test length(collect(ITensors.terms(H))) > 0
+end
+
+@testset "Hubbard1D: ModulatedModel wraps without error" begin
+    L = 4
+    m_ssd = modulated(Hubbard1D(; t=1.0, U=4.0); L=L, modulation=SSD())
+    sites = siteinds("Electron", L)
+    H = build_opsum(m_ssd, sites; phys_sites=1:L, boundary=:full)
+    @test length(collect(ITensors.terms(H))) > 0
+end
+
+@testset "Hubbard1D: DMRG smoke" begin
+    N = 4
+    t = 1.0
+    U = 4.0
+    m = Hubbard1D(; t=t, U=U, μ=-U / 2)
+    sites = siteinds("Electron", N)
+    H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
+    psi0 = random_mps(MersenneTwister(0x1c), sites; linkdims=16)
+    sweeps = Sweeps(15)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
+        200, 200, 200, 200, 200)
+    cutoff!(sweeps, 1e-12)
+    E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
+    @test isfinite(E)
+end


### PR DESCRIPTION
## Summary

1D single-band Fermi-Hubbard chain on `SiteType("Electron")` sites.

    H = -t Σ_{i,σ} (c†_{i,σ} c_{i+1,σ} + h.c.) + U Σ_i n_{i↑} n_{i↓} + μ Σ_i (n_{i↑} + n_{i↓})

First electron-site model in the package. 4-dim local Hilbert space; Jordan-Wigner strings handled by ITensors' OpSum → MPO conversion.

Strong-coupling limit U/t → ∞ at half-filling reduces to the spin-1/2 Heisenberg chain via super-exchange J = 4t²/U. Exactly solvable by Bethe ansatz (Lieb–Wu 1968).

## Test plan (60点)

- Construction, bond_coupling_term has 4 hopping terms with coefficient -t.
- onsite_term emits 3 terms (U·Nupdn + μ·Nup + μ·Ndn).
- Observable name lookup (:nup / :ndn / :n / :nupdn / :sz).
- build_opsum on N=4 Electron sites.
- ModulatedModel SSD wrap smoke.
- DMRG smoke at μ = -U/2 (particle-hole symmetric).

## Versioning

Bump 0.6.8 → 0.7.0 (minor: new public model). Parallel to #39 (S1Heisenberg minor) and #41 (TightBinding minor); whichever lands first gets 0.7.0, the others rebase to patch numbers.

## Follow-ups

- QAtlas bridge for Hubbard1D (QAtlas does not yet expose a 1D Hubbard struct).
- 2D LatticeModel + Hubbard1D bond (square / triangular / honeycomb).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
