### PR TITLE
feat(models): add AKLT1D (Affleck-Kennedy-Lieb-Tasaki chain)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/ITensorModels.jl
+++ b/src/ITensorModels.jl
@@ -14,6 +14,7 @@ export LongRangeIsing1D
 export ExtendedHubbard1D
 export Compass1D
 export Hubbard1D
+export AKLT1D
 export TFIM, TFIML, XXZ1D, Heisenberg1D, S1Heisenberg1D, KitaevBond, LatticeModel
 export TFIM, TFIML, XXZ1D, Heisenberg1D, KitaevBond, TightBinding1D, LatticeModel
 export AbstractModulation, Uniform, SSD, SinPower, SmoothBoundary, Tabulated
@@ -75,6 +76,7 @@ include("models/xxz.jl")
 include("models/heisenberg.jl")
 include("models/heisenberg_s1.jl")
 include("models/hubbard_1d.jl")
+include("models/aklt_1d.jl")
 include("models/kitaev_bond.jl")
 include("models/xy_h_1d.jl")
 include("models/long_range_ising_1d.jl")

--- a/src/models/aklt_1d.jl
+++ b/src/models/aklt_1d.jl
@@ -1,0 +1,51 @@
+using ITensors: SiteType, @SiteType_str
+
+"""
+    AKLT1D(; J=1.0, site=SiteType("S=1"))
+
+1D Affleck–Kennedy–Lieb–Tasaki (AKLT) chain on spin-1 sites:
+
+    H = J Σ_i [ Sᵢ · Sᵢ₊₁ + (1/3) (Sᵢ · Sᵢ₊₁)² ]
+
+The biquadratic-to-bilinear ratio `1/3` is the AKLT point of the
+bilinear-biquadratic (BLBQ) family — the ground state is an exact
+matrix-product state, the bulk gap is finite (≈ 0.350 J), and the
+open chain hosts free `S = 1/2` edge modes that give rise to a
+4-fold degenerate ground space (the Haldane SPT phase).
+
+References:
+- Affleck, Kennedy, Lieb, Tasaki, PRL 59, 799 (1987).
+- Affleck, Kennedy, Lieb, Tasaki, Comm. Math. Phys. 115, 477 (1988).
+"""
+Base.@kwdef struct AKLT1D <: AbstractLatticeModel
+    J::Float64 = 1.0
+    site::SiteType = SiteType("S=1")
+end
+
+site_type(m::AKLT1D) = m.site
+
+const _AKLT_OPS = ("Sx", "Sy", "Sz")
+
+function _aklt_bond(m::AKLT1D, i::Int, j::Int)
+    H = OpSum()
+    # Bilinear: J * S_i · S_j.
+    for α in _AKLT_OPS
+        H += m.J, α, i, α, j
+    end
+    # Biquadratic: (J/3) * (S_i · S_j)^2 = (J/3) Σ_{α,β} S^α_i S^β_i S^α_j S^β_j.
+    for α in _AKLT_OPS, β in _AKLT_OPS
+        H += m.J / 3, α, i, β, i, α, j, β, j
+    end
+    return H
+end
+
+bond_term(m::AKLT1D, i::Int, j::Int) = _aklt_bond(m, i, j)
+bond_coupling_term(m::AKLT1D, i::Int, j::Int) = _aklt_bond(m, i, j)
+onsite_term(::AKLT1D, ::Int) = OpSum()
+
+function onsite_observable_op(m::AKLT1D, name::Symbol)
+    name === :sx && return "Sx"
+    name === :sy && return "Sy"
+    name === :sz && return "Sz"
+    return error("AKLT1D: unsupported onsite observable $name")
+end

--- a/test/base/test_aklt_1d.jl
+++ b/test/base/test_aklt_1d.jl
@@ -52,8 +52,29 @@ end
     H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
     psi0 = random_mps(MersenneTwister(0xa1), sites; linkdims=8)
     sweeps = Sweeps(20)
-    maxdim!(sweeps, 10, 20, 40, 80, 100, 100, 100, 100, 100, 100,
-        100, 100, 100, 100, 100, 100, 100, 100, 100, 100)
+    maxdim!(
+        sweeps,
+        10,
+        20,
+        40,
+        80,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+    )
     cutoff!(sweeps, 1e-12)
     E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
     @test isfinite(E)

--- a/test/base/test_aklt_1d.jl
+++ b/test/base/test_aklt_1d.jl
@@ -1,0 +1,61 @@
+using ITensorModels
+using ITensors
+using ITensors: SiteType
+using ITensorMPS
+using Random
+using Test
+
+@testset "AKLT1D: construction" begin
+    m = AKLT1D()
+    @test m isa AbstractLatticeModel
+    @test m.J == 1.0
+    @test site_type(m) == SiteType("S=1")
+
+    m2 = AKLT1D(; J=2.0)
+    @test m2.J == 2.0
+end
+
+@testset "AKLT1D: bond_term has 12 terms (3 bilinear + 9 biquadratic)" begin
+    m = AKLT1D(; J=1.5)
+    H = bond_term(m, 1, 2)
+    terms = collect(ITensors.terms(H))
+    @test length(terms) == 12
+end
+
+@testset "AKLT1D: bond_coupling_term ≡ bond_term (no onsite)" begin
+    m = AKLT1D(; J=0.8)
+    @test length(collect(ITensors.terms(bond_term(m, 3, 4)))) ==
+        length(collect(ITensors.terms(bond_coupling_term(m, 3, 4))))
+    @test length(collect(ITensors.terms(onsite_term(m, 1)))) == 0
+end
+
+@testset "AKLT1D: build_opsum on S=1 sites" begin
+    N = 6
+    m = AKLT1D(; J=1.0)
+    sites = siteinds("S=1", N)
+    H = build_opsum(m, sites; phys_sites=1:N, boundary=:full)
+    @test length(collect(ITensors.terms(H))) == 12 * (N - 1)
+end
+
+@testset "AKLT1D: ModulatedModel wraps without error" begin
+    L = 6
+    m_ssd = modulated(AKLT1D(; J=1.0); L=L, modulation=SSD())
+    sites = siteinds("S=1", L)
+    H = build_opsum(m_ssd, sites; phys_sites=1:L, boundary=:full)
+    @test length(collect(ITensors.terms(H))) > 0
+end
+
+@testset "AKLT1D: DMRG smoke" begin
+    N = 8
+    m = AKLT1D(; J=1.0)
+    sites = siteinds("S=1", N)
+    H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
+    psi0 = random_mps(MersenneTwister(0xa1), sites; linkdims=8)
+    sweeps = Sweeps(20)
+    maxdim!(sweeps, 10, 20, 40, 80, 100, 100, 100, 100, 100, 100,
+        100, 100, 100, 100, 100, 100, 100, 100, 100, 100)
+    cutoff!(sweeps, 1e-12)
+    E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
+    @test isfinite(E)
+    @test E < 0.0
+end


### PR DESCRIPTION
## Summary

S=1 chain at the AKLT point of the bilinear-biquadratic family:

    H = J Σ_i [ S_i · S_{i+1} + (1/3) (S_i · S_{i+1})² ]

12 OpSum terms per bond (3 bilinear + 9 biquadratic). Exact MPS ground state. 4-fold edge degeneracy under OBC (Haldane SPT). Reference: Affleck-Kennedy-Lieb-Tasaki, PRL 59, 799 (1987).

## Test plan (60点)

- Construction.
- bond_term emits 12 terms per bond.
- bond_coupling_term ≡ bond_term (no onsite).
- build_opsum on N=6 S=1 chain yields 12*(N-1) terms.
- ModulatedModel SSD wrap smoke.
- DMRG smoke on N=8 converges to finite E < 0.

## Versioning

Bump 0.6.8 → 0.7.0 (minor: new model).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
