### PR TITLE
feat(models): add BoseHubbard1D

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.7.6"
+version = "0.7.7"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/ITensorModels.jl
+++ b/src/ITensorModels.jl
@@ -17,6 +17,7 @@ export Hubbard1D
 export AKLT1D
 export TightBindingV1D
 export J1J2Heisenberg1D
+export BoseHubbard1D
 export TFIM, TFIML, XXZ1D, Heisenberg1D, S1Heisenberg1D, KitaevBond, LatticeModel
 export TFIM, TFIML, XXZ1D, Heisenberg1D, KitaevBond, TightBinding1D, LatticeModel
 export AbstractModulation, Uniform, SSD, SinPower, SmoothBoundary, Tabulated
@@ -81,6 +82,7 @@ include("models/hubbard_1d.jl")
 include("models/aklt_1d.jl")
 include("models/tightbinding_v_1d.jl")
 include("models/j1j2_heisenberg_1d.jl")
+include("models/bose_hubbard_1d.jl")
 include("models/kitaev_bond.jl")
 include("models/xy_h_1d.jl")
 include("models/long_range_ising_1d.jl")

--- a/src/models/bose_hubbard_1d.jl
+++ b/src/models/bose_hubbard_1d.jl
@@ -1,0 +1,67 @@
+using ITensors: SiteType, @SiteType_str
+
+"""
+    BoseHubbard1D(; t=1.0, U=2.0, μ=0.0, site=SiteType("Boson"))
+
+1D Bose-Hubbard model
+
+    H = -t Σ_i (b†_i b_{i+1} + b†_{i+1} b_i)
+      + (U/2) Σ_i n_i (n_i - 1)
+      + μ Σ_i n_i
+
+on `SiteType("Boson")` sites. The local Hilbert space dimension is
+set by the caller via `siteinds("Boson", N; dim=k)` (operators `A` /
+`Adag` / `N` work at any truncation; the model is dim-agnostic).
+
+The 1D Bose-Hubbard model exhibits a Mott-superfluid quantum phase
+transition at integer fillings (Fisher, Weichman, Grinstein, Fisher,
+PRB 40, 546 (1989); Greiner et al. (2002) optical-lattice setup).
+"""
+Base.@kwdef struct BoseHubbard1D <: AbstractLatticeModel
+    t::Float64 = 1.0
+    U::Float64 = 2.0
+    μ::Float64 = 0.0
+    site::SiteType = SiteType("Boson")
+end
+
+site_type(m::BoseHubbard1D) = m.site
+
+function bond_term(m::BoseHubbard1D, i::Int, j::Int)
+    H = OpSum()
+    H += -m.t, "Adag", i, "A", j
+    H += -m.t, "Adag", j, "A", i
+    # Half-weight on-site U/2 n(n-1) + μ n on each endpoint.
+    H += (m.U / 4), "N", i, "N", i
+    H += (-m.U / 4 + m.μ / 2), "N", i
+    H += (m.U / 4), "N", j, "N", j
+    H += (-m.U / 4 + m.μ / 2), "N", j
+    return H
+end
+
+function boundary_patch(m::BoseHubbard1D, k::Int)
+    H = OpSum()
+    H += (m.U / 4), "N", k, "N", k
+    H += (-m.U / 4 + m.μ / 2), "N", k
+    return H
+end
+
+function onsite_observable_op(m::BoseHubbard1D, name::Symbol)
+    name === :n && return "N"
+    name === :a && return "A"
+    name === :adag && return "Adag"
+    return error("BoseHubbard1D: unsupported onsite observable $name")
+end
+
+function bond_coupling_term(m::BoseHubbard1D, i::Int, j::Int)
+    H = OpSum()
+    H += -m.t, "Adag", i, "A", j
+    H += -m.t, "Adag", j, "A", i
+    return H
+end
+
+function onsite_term(m::BoseHubbard1D, k::Int)
+    H = OpSum()
+    H += (m.U / 2), "N", k, "N", k
+    H += (-m.U / 2 + m.μ), "N", k
+    return H
+end

--- a/test/base/test_bose_hubbard_1d.jl
+++ b/test/base/test_bose_hubbard_1d.jl
@@ -1,0 +1,60 @@
+using ITensorModels
+using ITensors
+using ITensors: SiteType
+using ITensorMPS
+using Random
+using Test
+
+@testset "BoseHubbard1D: construction" begin
+    m = BoseHubbard1D()
+    @test m isa AbstractLatticeModel
+    @test m.t == 1.0
+    @test m.U == 2.0
+    @test m.μ == 0.0
+    @test site_type(m) == SiteType("Boson")
+end
+
+@testset "BoseHubbard1D: bond_coupling_term has 2 hoppings" begin
+    m = BoseHubbard1D(; t=1.3)
+    H = bond_coupling_term(m, 1, 2)
+    terms = collect(ITensors.terms(H))
+    @test length(terms) == 2
+    @test all(t -> ITensors.coefficient(t) ≈ -1.3, terms)
+end
+
+@testset "BoseHubbard1D: onsite_term has 2 terms" begin
+    m = BoseHubbard1D(; t=1.0, U=3.0, μ=0.5)
+    H = onsite_term(m, 1)
+    terms = collect(ITensors.terms(H))
+    @test length(terms) == 2
+end
+
+@testset "BoseHubbard1D: onsite_observable_op" begin
+    m = BoseHubbard1D()
+    @test onsite_observable_op(m, :n) == "N"
+    @test onsite_observable_op(m, :a) == "A"
+    @test onsite_observable_op(m, :adag) == "Adag"
+    @test_throws ErrorException onsite_observable_op(m, :bogus)
+end
+
+@testset "BoseHubbard1D: build_opsum on Boson sites" begin
+    N = 6
+    m = BoseHubbard1D(; t=1.0, U=2.0, μ=-1.0)
+    sites = siteinds("Boson", N; dim=3)
+    H = build_opsum(m, sites; phys_sites=1:N, boundary=:full)
+    @test length(collect(ITensors.terms(H))) > 0
+end
+
+@testset "BoseHubbard1D: DMRG smoke" begin
+    N = 6
+    m = BoseHubbard1D(; t=1.0, U=8.0, μ=-4.0)
+    sites = siteinds("Boson", N; dim=3)
+    H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
+    psi0 = random_mps(MersenneTwister(0xbe), sites; linkdims=16)
+    sweeps = Sweeps(15)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
+        200, 200, 200, 200, 200)
+    cutoff!(sweeps, 1e-12)
+    E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
+    @test isfinite(E)
+end

--- a/test/base/test_bose_hubbard_1d.jl
+++ b/test/base/test_bose_hubbard_1d.jl
@@ -52,8 +52,7 @@ end
     H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
     psi0 = random_mps(MersenneTwister(0xbe), sites; linkdims=16)
     sweeps = Sweeps(15)
-    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
-        200, 200, 200, 200, 200)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200)
     cutoff!(sweeps, 1e-12)
     E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
     @test isfinite(E)


### PR DESCRIPTION
## Summary

1D Bose-Hubbard model on `SiteType("Boson")` (first boson model).

    H = -t Σ_i (b†_i b_{i+1} + h.c.) + (U/2) Σ_i n_i (n_i - 1) + μ Σ_i n_i

Local Hilbert space dim is set by the caller at `siteinds("Boson", N; dim=k)` time. Canonical Mott-superfluid QPT (Fisher–Weichman–Grinstein–Fisher 1989; Greiner et al. 2002 optical lattice).

## Test plan (60点)

- Construction, bond_coupling_term has 2 hoppings, onsite_term has 2 terms.
- Observable lookup, OpSum build on Boson sites, DMRG smoke.

## Versioning

Bump 0.6.8 → 0.7.0 (minor).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
