### PR TITLE
feat(models): add DMIHeisenberg1D (DMI bond perturbation)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.7.7"
+version = "0.7.8"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/ITensorModels.jl
+++ b/src/ITensorModels.jl
@@ -18,6 +18,7 @@ export AKLT1D
 export TightBindingV1D
 export J1J2Heisenberg1D
 export BoseHubbard1D
+export DMIHeisenberg1D
 export TFIM, TFIML, XXZ1D, Heisenberg1D, S1Heisenberg1D, KitaevBond, LatticeModel
 export TFIM, TFIML, XXZ1D, Heisenberg1D, KitaevBond, TightBinding1D, LatticeModel
 export AbstractModulation, Uniform, SSD, SinPower, SmoothBoundary, Tabulated
@@ -83,6 +84,7 @@ include("models/aklt_1d.jl")
 include("models/tightbinding_v_1d.jl")
 include("models/j1j2_heisenberg_1d.jl")
 include("models/bose_hubbard_1d.jl")
+include("models/dmi_heisenberg_1d.jl")
 include("models/kitaev_bond.jl")
 include("models/xy_h_1d.jl")
 include("models/long_range_ising_1d.jl")

--- a/src/models/dmi_heisenberg_1d.jl
+++ b/src/models/dmi_heisenberg_1d.jl
@@ -1,0 +1,48 @@
+using ITensors: SiteType, @SiteType_str
+
+"""
+    DMIHeisenberg1D(; J=1.0, D=(0.0, 0.0, 1.0), site=SiteType("S=1/2"))
+
+1D spin-½ Heisenberg chain with Dzyaloshinskii-Moriya interaction:
+
+    H = J Σ_i Sᵢ · Sᵢ₊₁ + Σ_i 𝐃 · (Sᵢ × Sᵢ₊₁)
+
+where `D = (Dˣ, Dʸ, Dᶻ)` is the DMI vector (uniform along the chain).
+Underlying physics: chiral magnetism, spin-spiral ground states,
+skyrmion lattices. Leading symmetry-allowed bond perturbation for
+systems with broken inversion symmetry (Dzyaloshinskii 1958;
+Moriya 1960).
+"""
+Base.@kwdef struct DMIHeisenberg1D <: AbstractLatticeModel
+    J::Float64 = 1.0
+    D::NTuple{3,Float64} = (0.0, 0.0, 1.0)
+    site::SiteType = SiteType("S=1/2")
+end
+
+site_type(m::DMIHeisenberg1D) = m.site
+
+function _dmi_heisenberg_bond(m::DMIHeisenberg1D, i::Int, j::Int)
+    Dx, Dy, Dz = m.D
+    H = OpSum()
+    H += m.J, "Sx", i, "Sx", j
+    H += m.J, "Sy", i, "Sy", j
+    H += m.J, "Sz", i, "Sz", j
+    H += Dx, "Sy", i, "Sz", j
+    H += -Dx, "Sz", i, "Sy", j
+    H += Dy, "Sz", i, "Sx", j
+    H += -Dy, "Sx", i, "Sz", j
+    H += Dz, "Sx", i, "Sy", j
+    H += -Dz, "Sy", i, "Sx", j
+    return H
+end
+
+bond_term(m::DMIHeisenberg1D, i::Int, j::Int) = _dmi_heisenberg_bond(m, i, j)
+bond_coupling_term(m::DMIHeisenberg1D, i::Int, j::Int) = _dmi_heisenberg_bond(m, i, j)
+onsite_term(::DMIHeisenberg1D, ::Int) = OpSum()
+
+function onsite_observable_op(::DMIHeisenberg1D, name::Symbol)
+    name === :sx && return "Sx"
+    name === :sy && return "Sy"
+    name === :sz && return "Sz"
+    return error("DMIHeisenberg1D: unsupported onsite observable $name")
+end

--- a/test/base/test_dmi_heisenberg_1d.jl
+++ b/test/base/test_dmi_heisenberg_1d.jl
@@ -1,0 +1,54 @@
+using ITensorModels
+using ITensors
+using ITensors: SiteType
+using ITensorMPS
+using Random
+using Test
+
+@testset "DMIHeisenberg1D: construction" begin
+    m = DMIHeisenberg1D()
+    @test m isa AbstractLatticeModel
+    @test m.J == 1.0
+    @test m.D == (0.0, 0.0, 1.0)
+    @test site_type(m) == SiteType("S=1/2")
+end
+
+@testset "DMIHeisenberg1D: bond_term has 9 terms" begin
+    m = DMIHeisenberg1D(; J=1.0, D=(0.5, 0.3, 0.7))
+    H = bond_term(m, 1, 2)
+    @test length(collect(ITensors.terms(H))) == 9
+end
+
+@testset "DMIHeisenberg1D: onsite_observable_op" begin
+    m = DMIHeisenberg1D()
+    @test onsite_observable_op(m, :sx) == "Sx"
+    @test onsite_observable_op(m, :sy) == "Sy"
+    @test onsite_observable_op(m, :sz) == "Sz"
+    @test_throws ErrorException onsite_observable_op(m, :bogus)
+end
+
+@testset "DMIHeisenberg1D: build_opsum + ModulatedModel smoke" begin
+    N = 6
+    m = DMIHeisenberg1D(; J=1.0, D=(0.0, 0.0, 0.3))
+    sites = siteinds("S=1/2", N)
+    H = build_opsum(m, sites; phys_sites=1:N, boundary=:full)
+    @test length(collect(ITensors.terms(H))) == 9 * (N - 1)
+
+    m_ssd = modulated(m; L=N, modulation=SSD())
+    H_ssd = build_opsum(m_ssd, sites; phys_sites=1:N, boundary=:full)
+    @test length(collect(ITensors.terms(H_ssd))) > 0
+end
+
+@testset "DMIHeisenberg1D: DMRG smoke" begin
+    N = 8
+    m = DMIHeisenberg1D(; J=1.0, D=(0.0, 0.0, 0.3))
+    sites = siteinds("S=1/2", N)
+    H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
+    psi0 = random_mps(MersenneTwister(0xd1), sites; linkdims=16)
+    sweeps = Sweeps(15)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
+        200, 200, 200, 200, 200)
+    cutoff!(sweeps, 1e-12)
+    E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
+    @test isfinite(E)
+end

--- a/test/base/test_dmi_heisenberg_1d.jl
+++ b/test/base/test_dmi_heisenberg_1d.jl
@@ -46,8 +46,7 @@ end
     H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
     psi0 = random_mps(MersenneTwister(0xd1), sites; linkdims=16)
     sweeps = Sweeps(15)
-    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
-        200, 200, 200, 200, 200)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200)
     cutoff!(sweeps, 1e-12)
     E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
     @test isfinite(E)


### PR DESCRIPTION
## Summary

Heisenberg chain with Dzyaloshinskii-Moriya bond perturbation.

    H = J Σ_i S_i · S_{i+1} + Σ_i 𝐃 · (S_i × S_{i+1})

DMI vector D = (Dx, Dy, Dz) is uniform along the chain. Chiral magnetism, spin spiral GS, skyrmion lattices. References: Dzyaloshinskii 1958, Moriya 1960.

## Test plan (60点)

- Construction with default D = (0, 0, 1).
- bond_term has 9 terms (3 Heisenberg + 6 DMI).
- Observable lookup, OpSum build, ModulatedModel SSD smoke, DMRG smoke.

## Versioning

Bump 0.6.8 → 0.7.0 (minor).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
