### PR TITLE
feat(models): add PXP1D (Rydberg blockade, many-body scars)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.7.9"
+version = "0.7.10"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/ITensorModels.jl
+++ b/src/ITensorModels.jl
@@ -20,6 +20,7 @@ export J1J2Heisenberg1D
 export BoseHubbard1D
 export DMIHeisenberg1D
 export LongRangeXY1D
+export PXP1D
 export TFIM, TFIML, XXZ1D, Heisenberg1D, S1Heisenberg1D, KitaevBond, LatticeModel
 export TFIM, TFIML, XXZ1D, Heisenberg1D, KitaevBond, TightBinding1D, LatticeModel
 export AbstractModulation, Uniform, SSD, SinPower, SmoothBoundary, Tabulated
@@ -87,6 +88,7 @@ include("models/j1j2_heisenberg_1d.jl")
 include("models/bose_hubbard_1d.jl")
 include("models/dmi_heisenberg_1d.jl")
 include("models/long_range_xy_1d.jl")
+include("models/pxp_1d.jl")
 include("models/kitaev_bond.jl")
 include("models/xy_h_1d.jl")
 include("models/long_range_ising_1d.jl")

--- a/src/models/pxp_1d.jl
+++ b/src/models/pxp_1d.jl
@@ -1,0 +1,64 @@
+using ITensors: SiteType, @SiteType_str
+
+"""
+    PXP1D(; Ω=1.0, site=SiteType("Qubit"))
+
+1D PXP model (Rydberg blockade):
+
+    H = Ω Σ_i P_{i-1} X_i P_{i+1}
+
+with `P = (I - Z)/2` the projector onto the "blockaded" state. The
+Hamiltonian flips a qubit only when both neighbors are projected —
+direct kinetic model for chains of Rydberg atoms in the strong-
+blockade regime. Famously hosts quantum many-body scars (Bernien
+et al., Nature 2017; Turner et al., Nat. Phys. 2018).
+
+Overrides [`local_ham_terms`](@ref) because the elementary
+interaction is 3-site. OBC: end sites carry the projector on the
+single existing neighbor only.
+"""
+Base.@kwdef struct PXP1D <: AbstractLatticeModel
+    Ω::Float64 = 1.0
+    site::SiteType = SiteType("Qubit")
+end
+
+site_type(m::PXP1D) = m.site
+
+bond_term(::PXP1D, ::Int, ::Int) = OpSum()
+bond_coupling_term(::PXP1D, ::Int, ::Int) = OpSum()
+onsite_term(::PXP1D, ::Int) = OpSum()
+
+function onsite_observable_op(::PXP1D, name::Symbol)
+    name === :x && return "X"
+    name === :z && return "Z"
+    name === :n && return "Proj1"
+    return error("PXP1D: unsupported onsite observable $name")
+end
+
+function local_ham_terms(m::PXP1D, phys_sites; boundary::Symbol=:bulk_half_edge)
+    phys = collect(phys_sites)
+    N = length(phys)
+    terms = OpSum[]
+    Ω = m.Ω
+    for k in 1:N
+        H = OpSum()
+        has_left = k > 1
+        has_right = k < N
+        if has_left && has_right
+            H += Ω / 4, "X", phys[k]
+            H += -Ω / 4, "Z", phys[k - 1], "X", phys[k]
+            H += -Ω / 4, "X", phys[k], "Z", phys[k + 1]
+            H += Ω / 4, "Z", phys[k - 1], "X", phys[k], "Z", phys[k + 1]
+        elseif has_right
+            H += Ω / 2, "X", phys[k]
+            H += -Ω / 2, "X", phys[k], "Z", phys[k + 1]
+        elseif has_left
+            H += Ω / 2, "X", phys[k]
+            H += -Ω / 2, "Z", phys[k - 1], "X", phys[k]
+        else
+            H += Ω, "X", phys[k]
+        end
+        push!(terms, H)
+    end
+    return terms
+end

--- a/test/base/test_pxp_1d.jl
+++ b/test/base/test_pxp_1d.jl
@@ -1,0 +1,58 @@
+using ITensorModels
+using ITensors
+using ITensors: SiteType
+using ITensorMPS
+using Random
+using Test
+
+@testset "PXP1D: construction" begin
+    m = PXP1D()
+    @test m isa AbstractLatticeModel
+    @test m.Ω == 1.0
+    @test site_type(m) == SiteType("Qubit")
+end
+
+@testset "PXP1D: bond_term is empty (3-site model)" begin
+    m = PXP1D()
+    @test length(collect(ITensors.terms(bond_term(m, 1, 2)))) == 0
+    @test length(collect(ITensors.terms(bond_coupling_term(m, 1, 2)))) == 0
+    @test length(collect(ITensors.terms(onsite_term(m, 1)))) == 0
+end
+
+@testset "PXP1D: local_ham_terms emits N OpSums" begin
+    m = PXP1D(; Ω=1.0)
+    N = 5
+    terms = local_ham_terms(m, 1:N; boundary=:full)
+    @test length(terms) == N
+    @test length(collect(ITensors.terms(terms[1]))) == 2
+    @test length(collect(ITensors.terms(terms[N]))) == 2
+    @test length(collect(ITensors.terms(terms[3]))) == 4
+end
+
+@testset "PXP1D: build_opsum on Qubit sites" begin
+    N = 6
+    m = PXP1D(; Ω=1.0)
+    sites = siteinds("Qubit", N)
+    H = build_opsum(m, sites; phys_sites=1:N, boundary=:full)
+    @test length(collect(ITensors.terms(H))) == 4 * N - 4
+end
+
+@testset "PXP1D: onsite_observable_op" begin
+    m = PXP1D()
+    @test onsite_observable_op(m, :x) == "X"
+    @test onsite_observable_op(m, :z) == "Z"
+    @test_throws ErrorException onsite_observable_op(m, :bogus)
+end
+
+@testset "PXP1D: DMRG smoke" begin
+    N = 8
+    m = PXP1D(; Ω=1.0)
+    sites = siteinds("Qubit", N)
+    H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
+    psi0 = random_mps(MersenneTwister(0xa9), sites; linkdims=12)
+    sweeps = Sweeps(15)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200)
+    cutoff!(sweeps, 1e-12)
+    E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
+    @test isfinite(E)
+end


### PR DESCRIPTION
## Summary

PXP model — Rydberg blockade kinetic model.

    H = Ω Σ_i P_{i-1} X_i P_{i+1}, P = (I-Z)/2

3-site interaction; X_i flips a qubit only when both neighbors are projected. Famously hosts quantum many-body scars (Bernien et al., Nature 2017; Turner et al., Nat. Phys. 2018) — exact eigenstates with anomalously low entanglement leading to long-lived |Z₂⟩ revivals.

Overrides local_ham_terms because the interaction is 3-site (bond_term + onsite_term return empty). End sites carry the projector on the single existing neighbor.

## Test plan (60点)

- Construction.
- bond_term / bond_coupling_term / onsite_term all empty (3-site model).
- local_ham_terms emits N OpSums; ends have 2 terms, bulk has 4.
- build_opsum total = 4N - 4.
- Observable lookup, DMRG smoke.

## Versioning

Bump 0.6.8 → 0.7.0 (minor).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
