### PR TITLE
feat: LongRangeIsing1D — 1D power-law transverse-field Ising

### DIFF
--- a/src/ITensorModels.jl
+++ b/src/ITensorModels.jl
@@ -10,6 +10,7 @@ export bond_coupling_term, onsite_term
 export onsite_observable_op, build_onsite_observable_opsum
 export TFIM, TFIML, XXZ1D, Heisenberg1D, KitaevBond, LatticeModel
 export XYh1D
+export LongRangeIsing1D
 export AbstractModulation, Uniform, SSD, SinPower, SmoothBoundary, Tabulated
 export site_weight, bond_weight
 export ModulatedModel, modulated
@@ -69,6 +70,7 @@ include("models/xxz.jl")
 include("models/heisenberg.jl")
 include("models/kitaev_bond.jl")
 include("models/xy_h_1d.jl")
+include("models/long_range_ising_1d.jl")
 include("models/lattice_model.jl")
 include("models/modulated.jl")
 include("models/modulated_lattice.jl")

--- a/src/models/long_range_ising_1d.jl
+++ b/src/models/long_range_ising_1d.jl
@@ -1,0 +1,60 @@
+using ITensors: SiteType, @SiteType_str
+
+"""
+    LongRangeIsing1D(; J=1.0, α=3.0, h=0.0, site=SiteType("Qubit"))
+
+1D power-law transverse-field Ising model:
+
+    H = -Σ_{i<j} [J / |i-j|^α] Z_i Z_j  -  h Σ_i X_i
+
+on `SiteType("Qubit")`. Power-law ZZ couplings (positive `J` =
+ferromagnetic). `α → ∞` recovers the nearest-neighbor TFIM; `α < 2`
+enters the strong-long-range regime.
+
+Direct model for trapped-ion arrays (Britton et al., Nature 2012)
+and 1D Rydberg dipole-dipole simulators (`α = 3`).
+"""
+Base.@kwdef struct LongRangeIsing1D <: AbstractLatticeModel
+    J::Float64 = 1.0
+    α::Float64 = 3.0
+    h::Float64 = 0.0
+    site::SiteType = SiteType("Qubit")
+end
+
+site_type(m::LongRangeIsing1D) = m.site
+
+bond_term(::LongRangeIsing1D, ::Int, ::Int) = OpSum()
+bond_coupling_term(::LongRangeIsing1D, ::Int, ::Int) = OpSum()
+
+function onsite_term(m::LongRangeIsing1D, k::Int)
+    H = OpSum()
+    H += -m.h, "X", k
+    return H
+end
+
+function onsite_observable_op(::LongRangeIsing1D, name::Symbol)
+    name === :x && return "X"
+    name === :y && return "Y"
+    name === :z && return "Z"
+    return error("LongRangeIsing1D: unsupported onsite observable $name")
+end
+
+function local_ham_terms(m::LongRangeIsing1D, phys_sites; boundary::Symbol=:bulk_half_edge)
+    phys = collect(phys_sites)
+    N = length(phys)
+    terms = OpSum[]
+    for i in 1:(N - 1), j in (i + 1):N
+        Jij = m.J / abs(i - j)^m.α
+        H = OpSum()
+        H += -Jij, "Z", phys[i], "Z", phys[j]
+        push!(terms, H)
+    end
+    if !iszero(m.h)
+        for k in 1:N
+            H = OpSum()
+            H += -m.h, "X", phys[k]
+            push!(terms, H)
+        end
+    end
+    return terms
+end

--- a/test/base/test_long_range_ising_1d.jl
+++ b/test/base/test_long_range_ising_1d.jl
@@ -1,0 +1,76 @@
+using ITensorModels
+using ITensors
+using ITensors: SiteType
+using ITensorMPS
+using Random
+using Test
+
+@testset "LongRangeIsing1D: construction" begin
+    m = LongRangeIsing1D()
+    @test m isa AbstractLatticeModel
+    @test m.J == 1.0
+    @test m.α == 3.0
+    @test m.h == 0.0
+    @test site_type(m) == SiteType("Qubit")
+end
+
+@testset "LongRangeIsing1D: pairwise / onsite bond_term empty" begin
+    m = LongRangeIsing1D(; J=1.0, α=2.5, h=0.3)
+    @test length(collect(ITensors.terms(bond_term(m, 1, 2)))) == 0
+    @test length(collect(ITensors.terms(bond_coupling_term(m, 1, 2)))) == 0
+end
+
+@testset "LongRangeIsing1D: onsite_term has 1 (-h X)" begin
+    m = LongRangeIsing1D(; J=1.0, α=3.0, h=0.7)
+    H = onsite_term(m, 4)
+    terms = collect(ITensors.terms(H))
+    @test length(terms) == 1
+    @test ITensors.coefficient(terms[1]) ≈ -0.7
+end
+
+@testset "LongRangeIsing1D: local_ham_terms emits N(N-1)/2 ZZ + N X" begin
+    N = 5
+    m = LongRangeIsing1D(; J=1.0, α=3.0, h=0.5)
+    terms = local_ham_terms(m, 1:N; boundary=:full)
+    @test length(terms) == div(N * (N - 1), 2) + N
+end
+
+@testset "LongRangeIsing1D: local_ham_terms with h=0 drops X tail" begin
+    N = 4
+    m = LongRangeIsing1D(; J=1.0, α=3.0, h=0.0)
+    terms = local_ham_terms(m, 1:N; boundary=:full)
+    @test length(terms) == div(N * (N - 1), 2)
+end
+
+@testset "LongRangeIsing1D: onsite_observable_op" begin
+    m = LongRangeIsing1D()
+    @test onsite_observable_op(m, :x) == "X"
+    @test onsite_observable_op(m, :y) == "Y"
+    @test onsite_observable_op(m, :z) == "Z"
+    @test_throws ErrorException onsite_observable_op(m, :bogus)
+end
+
+@testset "LongRangeIsing1D: α large recovers near-NN TFIM (DMRG smoke)" begin
+    # With very large α, only nearest-neighbor ZZ couplings are numerically
+    # relevant; the GS is a ferromagnetic / paramagnetic competition.
+    N = 6
+    m = LongRangeIsing1D(; J=1.0, α=20.0, h=0.5)
+    sites = siteinds("Qubit", N)
+    H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
+    psi0 = random_mps(MersenneTwister(0xdf), sites; linkdims=12)
+    sweeps = Sweeps(15)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
+        200, 200, 200, 200, 200)
+    cutoff!(sweeps, 1e-12)
+    E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
+    @test isfinite(E)
+    @test E < 0
+end
+
+@testset "LongRangeIsing1D: build_opsum on Qubit sites" begin
+    N = 5
+    m = LongRangeIsing1D(; J=1.0, α=2.0, h=0.3)
+    sites = siteinds("Qubit", N)
+    H = build_opsum(m, sites; phys_sites=1:N, boundary=:full)
+    @test length(collect(ITensors.terms(H))) > 0
+end


### PR DESCRIPTION
## Summary

Add **LongRangeIsing1D** — 1D power-law transverse-field Ising model:

```
H = -Σ_{i<j} (J / |i-j|^α) Z_i Z_j  -  h Σ_i X_i
```

on `SiteType("Qubit")`. Power-law ZZ couplings (positive `J` = ferromagnetic).
`α → ∞` recovers the nearest-neighbor TFIM; `α < 2` enters the strong-long-range regime.

Direct model for **trapped-ion arrays** (Britton et al., *Nature* 2012) and 1D **Rydberg dipole-dipole** simulators (`α = 3`).

## Design notes

- Non-pair-decomposable: `bond_term` / `bond_coupling_term` return empty OpSum.
- Overrides `local_ham_terms` to emit all N(N-1)/2 ZZ pairs + on-site -h X tail (skipped when h=0).
- Tagged version bump 0.6.8 → 0.7.0 (additive only).

## Test plan

- [x] Construction defaults (J=1, α=3, h=0, SiteType("Qubit"))
- [x] Pairwise bond_term / bond_coupling_term are empty
- [x] onsite_term emits a single -h X term
- [x] local_ham_terms count = N(N-1)/2 + N (with h≠0) / N(N-1)/2 (with h=0)
- [x] onsite_observable_op lookup + error path
- [x] DMRG smoke at large α (α=20) — finite, negative ground-state energy
- [x] build_opsum non-empty on Qubit sites
