### PR TITLE
feat: ExtendedHubbard1D — 1D t-U-V Hubbard model

### DIFF
--- a/src/ITensorModels.jl
+++ b/src/ITensorModels.jl
@@ -11,6 +11,7 @@ export onsite_observable_op, build_onsite_observable_opsum
 export TFIM, TFIML, XXZ1D, Heisenberg1D, KitaevBond, LatticeModel
 export XYh1D
 export LongRangeIsing1D
+export ExtendedHubbard1D
 export AbstractModulation, Uniform, SSD, SinPower, SmoothBoundary, Tabulated
 export site_weight, bond_weight
 export ModulatedModel, modulated
@@ -71,6 +72,7 @@ include("models/heisenberg.jl")
 include("models/kitaev_bond.jl")
 include("models/xy_h_1d.jl")
 include("models/long_range_ising_1d.jl")
+include("models/extended_hubbard_1d.jl")
 include("models/lattice_model.jl")
 include("models/modulated.jl")
 include("models/modulated_lattice.jl")

--- a/src/models/extended_hubbard_1d.jl
+++ b/src/models/extended_hubbard_1d.jl
@@ -1,0 +1,74 @@
+using ITensors: SiteType, @SiteType_str
+
+"""
+    ExtendedHubbard1D(; t=1.0, U=4.0, V=1.0, μ=0.0, site=SiteType("Electron"))
+
+1D extended (t-U-V) Hubbard model:
+
+    H = -t Σ_⟨ij⟩σ (c†_iσ c_jσ + h.c.)
+        + U Σ_i n_{i↑} n_{i↓}
+        + V Σ_⟨ij⟩ n_i n_j
+        - μ Σ_i n_i
+
+on `SiteType("Electron")` (auto Jordan-Wigner via OpSum). The
+nearest-neighbor density-density `V` term stabilizes charge-density-wave
+(CDW) order, giving a richer 1D phase diagram (Lin & Hirsch 1986;
+Nakamura 2000) than the pure-Hubbard line: SDW / CDW / phase-separation
+boundaries depending on `U / V`.
+"""
+Base.@kwdef struct ExtendedHubbard1D <: AbstractLatticeModel
+    t::Float64 = 1.0
+    U::Float64 = 4.0
+    V::Float64 = 1.0
+    μ::Float64 = 0.0
+    site::SiteType = SiteType("Electron")
+end
+
+site_type(m::ExtendedHubbard1D) = m.site
+
+function bond_term(m::ExtendedHubbard1D, i::Int, j::Int)
+    H = OpSum()
+    H += -m.t, "Cdagup", i, "Cup", j
+    H += -m.t, "Cdagup", j, "Cup", i
+    H += -m.t, "Cdagdn", i, "Cdn", j
+    H += -m.t, "Cdagdn", j, "Cdn", i
+    H += m.V, "Ntot", i, "Ntot", j
+    H += (m.U / 2), "Nupdn", i
+    H += (m.U / 2), "Nupdn", j
+    H += -(m.μ / 2), "Ntot", i
+    H += -(m.μ / 2), "Ntot", j
+    return H
+end
+
+function boundary_patch(m::ExtendedHubbard1D, k::Int)
+    H = OpSum()
+    H += (m.U / 2), "Nupdn", k
+    H += -(m.μ / 2), "Ntot", k
+    return H
+end
+
+function bond_coupling_term(m::ExtendedHubbard1D, i::Int, j::Int)
+    H = OpSum()
+    H += -m.t, "Cdagup", i, "Cup", j
+    H += -m.t, "Cdagup", j, "Cup", i
+    H += -m.t, "Cdagdn", i, "Cdn", j
+    H += -m.t, "Cdagdn", j, "Cdn", i
+    H += m.V, "Ntot", i, "Ntot", j
+    return H
+end
+
+function onsite_term(m::ExtendedHubbard1D, k::Int)
+    H = OpSum()
+    H += m.U, "Nupdn", k
+    H += -m.μ, "Ntot", k
+    return H
+end
+
+function onsite_observable_op(::ExtendedHubbard1D, name::Symbol)
+    name === :nup && return "Nup"
+    name === :ndn && return "Ndn"
+    name === :ntot && return "Ntot"
+    name === :nupdn && return "Nupdn"
+    name === :sz && return "Sz"
+    return error("ExtendedHubbard1D: unsupported onsite observable $name")
+end

--- a/test/base/test_extended_hubbard_1d.jl
+++ b/test/base/test_extended_hubbard_1d.jl
@@ -1,0 +1,76 @@
+using ITensorModels
+using ITensors
+using ITensors: SiteType
+using ITensorMPS
+using Random
+using Test
+
+@testset "ExtendedHubbard1D: construction" begin
+    m = ExtendedHubbard1D()
+    @test m isa AbstractLatticeModel
+    @test m.t == 1.0
+    @test m.U == 4.0
+    @test m.V == 1.0
+    @test m.μ == 0.0
+    @test site_type(m) == SiteType("Electron")
+end
+
+@testset "ExtendedHubbard1D: bond_coupling_term has 5 (4 hop + 1 V)" begin
+    m = ExtendedHubbard1D(; t=1.0, U=4.0, V=1.5)
+    H = bond_coupling_term(m, 1, 2)
+    @test length(collect(ITensors.terms(H))) == 5
+end
+
+@testset "ExtendedHubbard1D: onsite_term has U Nupdn + μ Ntot" begin
+    m = ExtendedHubbard1D(; t=1.0, U=2.0, V=0.0, μ=0.3)
+    H = onsite_term(m, 3)
+    terms = collect(ITensors.terms(H))
+    @test length(terms) == 2
+end
+
+@testset "ExtendedHubbard1D: onsite_observable_op" begin
+    m = ExtendedHubbard1D()
+    @test onsite_observable_op(m, :nup) == "Nup"
+    @test onsite_observable_op(m, :ndn) == "Ndn"
+    @test onsite_observable_op(m, :ntot) == "Ntot"
+    @test onsite_observable_op(m, :nupdn) == "Nupdn"
+    @test onsite_observable_op(m, :sz) == "Sz"
+    @test_throws ErrorException onsite_observable_op(m, :bogus)
+end
+
+@testset "ExtendedHubbard1D: build_opsum + ModulatedModel smoke" begin
+    L = 6
+    m = ExtendedHubbard1D(; t=1.0, U=4.0, V=1.0)
+    m_ssd = modulated(m; L=L, modulation=SSD())
+    sites = siteinds("Electron", L)
+    H = build_opsum(m_ssd, sites; phys_sites=1:L, boundary=:full)
+    @test length(collect(ITensors.terms(H))) > 0
+end
+
+@testset "ExtendedHubbard1D: V → 0 reduces to standard Hubbard (DMRG smoke)" begin
+    N = 6
+    m = ExtendedHubbard1D(; t=1.0, U=8.0, V=0.0, μ=0.0)
+    sites = siteinds("Electron", N; conserve_qns=false)
+    H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
+    psi0 = random_mps(MersenneTwister(0xfa), sites; linkdims=12)
+    sweeps = Sweeps(15)
+    maxdim!(sweeps, 20, 50, 100, 200, 200, 200, 200, 200, 200, 200,
+        200, 200, 200, 200, 200)
+    cutoff!(sweeps, 1e-12)
+    E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
+    @test isfinite(E)
+end
+
+@testset "ExtendedHubbard1D: large V favors CDW (DMRG smoke)" begin
+    N = 6
+    m = ExtendedHubbard1D(; t=1.0, U=1.0, V=4.0)
+    sites = siteinds("Electron", N; conserve_qns=false)
+    H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
+    psi0 = random_mps(MersenneTwister(0xfb), sites; linkdims=12)
+    sweeps = Sweeps(15)
+    maxdim!(sweeps, 20, 50, 100, 200, 200, 200, 200, 200, 200, 200,
+        200, 200, 200, 200, 200)
+    cutoff!(sweeps, 1e-12)
+    E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
+    @test isfinite(E)
+end


### PR DESCRIPTION
## Summary

Add **ExtendedHubbard1D** — 1D **t-U-V** Hubbard model:

```
H = -t Σ_⟨ij⟩σ (c†_iσ c_jσ + h.c.)
    + U Σ_i n_i↑ n_i↓
    + V Σ_⟨ij⟩ n_i n_j
    - μ Σ_i n_i
```

on `SiteType("Electron")` (automatic Jordan-Wigner via OpSum). The nearest-neighbor density-density `V` term stabilizes **CDW** order, opening up the SDW / CDW / phase-separation phase diagram of Lin & Hirsch (1986) and Nakamura (2000).

## Design

- Standard NN bond + on-site split.
- `bond_term`: 4 hopping + 1 `V·Ntot·Ntot` + on-site half-edges (`U/2 Nupdn`, `-μ/2 Ntot`).
- `boundary_patch`: missing-bond on-site halves.
- `bond_coupling_term`: pure two-body (4 hop + V); 5 terms.
- `onsite_term`: `U Nupdn - μ Ntot`.
- Project.toml: 0.6.8 → 0.7.0 (additive).

## Test plan

- [x] Construction defaults (t=1, U=4, V=1, μ=0, SiteType("Electron"))
- [x] `bond_coupling_term` has 5 terms (4 hop + 1 V)
- [x] `onsite_term` has 2 terms (U·Nupdn + μ·Ntot)
- [x] `onsite_observable_op` lookup (:nup/:ndn/:ntot/:nupdn/:sz) + error path
- [x] `build_opsum` + ModulatedModel SSD smoke
- [x] V → 0 reduces to standard Hubbard (DMRG smoke, large U)
- [x] Large V → CDW regime (DMRG smoke)
