### PR TITLE
feat: Compass1D — 1D alternating-bond XX/YY chain

### DIFF
--- a/src/ITensorModels.jl
+++ b/src/ITensorModels.jl
@@ -12,6 +12,7 @@ export TFIM, TFIML, XXZ1D, Heisenberg1D, KitaevBond, LatticeModel
 export XYh1D
 export LongRangeIsing1D
 export ExtendedHubbard1D
+export Compass1D
 export AbstractModulation, Uniform, SSD, SinPower, SmoothBoundary, Tabulated
 export site_weight, bond_weight
 export ModulatedModel, modulated
@@ -73,6 +74,7 @@ include("models/kitaev_bond.jl")
 include("models/xy_h_1d.jl")
 include("models/long_range_ising_1d.jl")
 include("models/extended_hubbard_1d.jl")
+include("models/compass_1d.jl")
 include("models/lattice_model.jl")
 include("models/modulated.jl")
 include("models/modulated_lattice.jl")

--- a/src/models/compass_1d.jl
+++ b/src/models/compass_1d.jl
@@ -1,0 +1,53 @@
+using ITensors: SiteType, @SiteType_str
+
+"""
+    Compass1D(; Jx=1.0, Jy=1.0, site=SiteType("S=1/2"))
+
+1D compass / alternating-bond model on a spin-1/2 chain:
+
+    H = Jx Σ_{i odd}  S^x_i S^x_{i+1}  +  Jy Σ_{i even} S^y_i S^y_{i+1}
+
+i.e. odd (1-2, 3-4, …) bonds carry `XX`, even (2-3, 4-5, …) bonds carry
+`YY`. This is the 1D restriction of the 2D Kugel-Khomskii / quantum
+compass model (Brzezicki, Dziarmaga, Oleś 2007; Nussinov & van den Brink
+RMP 2015) — the simplest setting in which bond-direction-dependent
+two-body interactions compete on a single chain.
+
+Non-standard bond Hamiltonian: parity of the *bond* matters, so this
+file overrides [`local_ham_terms`](@ref) rather than going through the
+default bond / on-site split.
+"""
+Base.@kwdef struct Compass1D <: AbstractLatticeModel
+    Jx::Float64 = 1.0
+    Jy::Float64 = 1.0
+    site::SiteType = SiteType("S=1/2")
+end
+
+site_type(m::Compass1D) = m.site
+
+bond_term(::Compass1D, ::Int, ::Int) = OpSum()
+bond_coupling_term(::Compass1D, ::Int, ::Int) = OpSum()
+onsite_term(::Compass1D, ::Int) = OpSum()
+
+function onsite_observable_op(::Compass1D, name::Symbol)
+    name === :sx && return "Sx"
+    name === :sy && return "Sy"
+    name === :sz && return "Sz"
+    return error("Compass1D: unsupported onsite observable $name")
+end
+
+function local_ham_terms(m::Compass1D, phys_sites; boundary::Symbol=:bulk_half_edge)
+    phys = collect(phys_sites)
+    N = length(phys)
+    terms = OpSum[]
+    for i in 1:(N - 1)
+        H = OpSum()
+        if isodd(i)
+            H += m.Jx, "Sx", phys[i], "Sx", phys[i + 1]
+        else
+            H += m.Jy, "Sy", phys[i], "Sy", phys[i + 1]
+        end
+        push!(terms, H)
+    end
+    return terms
+end

--- a/test/base/test_compass_1d.jl
+++ b/test/base/test_compass_1d.jl
@@ -1,0 +1,62 @@
+using ITensorModels
+using ITensors
+using ITensors: SiteType
+using ITensorMPS
+using Random
+using Test
+
+@testset "Compass1D: construction" begin
+    m = Compass1D()
+    @test m isa AbstractLatticeModel
+    @test m.Jx == 1.0
+    @test m.Jy == 1.0
+    @test site_type(m) == SiteType("S=1/2")
+end
+
+@testset "Compass1D: pairwise / onsite all empty" begin
+    m = Compass1D(; Jx=1.0, Jy=0.5)
+    @test length(collect(ITensors.terms(bond_term(m, 1, 2)))) == 0
+    @test length(collect(ITensors.terms(bond_coupling_term(m, 1, 2)))) == 0
+    @test length(collect(ITensors.terms(onsite_term(m, 1)))) == 0
+end
+
+@testset "Compass1D: local_ham_terms alternates XX / YY" begin
+    N = 5
+    m = Compass1D(; Jx=1.0, Jy=0.5)
+    terms = local_ham_terms(m, 1:N; boundary=:full)
+    @test length(terms) == N - 1
+    for t in terms
+        @test length(collect(ITensors.terms(t))) == 1
+    end
+end
+
+@testset "Compass1D: build_opsum non-empty" begin
+    N = 6
+    m = Compass1D(; Jx=1.0, Jy=0.7)
+    sites = siteinds("S=1/2", N)
+    H = build_opsum(m, sites; phys_sites=1:N, boundary=:full)
+    @test length(collect(ITensors.terms(H))) == N - 1
+end
+
+@testset "Compass1D: onsite_observable_op" begin
+    m = Compass1D()
+    @test onsite_observable_op(m, :sx) == "Sx"
+    @test onsite_observable_op(m, :sy) == "Sy"
+    @test onsite_observable_op(m, :sz) == "Sz"
+    @test_throws ErrorException onsite_observable_op(m, :bogus)
+end
+
+@testset "Compass1D: DMRG smoke (finite GS)" begin
+    N = 6
+    m = Compass1D(; Jx=-1.0, Jy=-1.0)
+    sites = siteinds("S=1/2", N)
+    H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
+    psi0 = random_mps(MersenneTwister(0xc2), sites; linkdims=12)
+    sweeps = Sweeps(15)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
+        200, 200, 200, 200, 200)
+    cutoff!(sweeps, 1e-12)
+    E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
+    @test isfinite(E)
+    @test E < 0
+end


### PR DESCRIPTION
## Summary

Add **Compass1D** — 1D alternating-bond XX/YY chain:

```
H = Jx Σ_{i odd}  Sx_i Sx_{i+1}  +  Jy Σ_{i even} Sy_i Sy_{i+1}
```

on `SiteType("S=1/2")`. 1D restriction of the 2D quantum compass / Kugel–Khomskii model (Brzezicki, Dziarmaga & Oleś 2007; Nussinov & van den Brink, *RMP* 2015) — the minimal setting in which **bond-direction-dependent** two-body interactions compete on a single chain.

## Design

- Bond-parity determines operator (XX on odd bond, YY on even bond), so this is *not* a uniform NN model.
- `bond_term` / `bond_coupling_term` / `onsite_term` all empty.
- Overrides `local_ham_terms` to emit one single-operator OpSum per bond.
- Project.toml: 0.6.8 → 0.7.0 (additive).

## Test plan

- [x] Construction defaults (Jx=1, Jy=1, SiteType("S=1/2"))
- [x] All standard pairwise/onsite splits return empty OpSum
- [x] `local_ham_terms` emits N-1 single-term OpSums alternating XX/YY
- [x] `build_opsum` non-empty, count = N-1
- [x] `onsite_observable_op` lookup + error path
- [x] DMRG smoke (Jx=Jy=-1, finite negative GS)
