### PR TITLE
feat: XYh1D — 1D anisotropic XY chain in transverse field (LSM)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.6.8"
+version = "0.7.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/examples/plot_modulation_1d.jl
+++ b/examples/plot_modulation_1d.jl
@@ -6,55 +6,55 @@ using Plots
 const L = 60
 
 modulations = [
-    ("Uniform",         Uniform()),
-    ("SSD",             SSD()),
-    ("SinPower{4}",     SinPower{4}()),
-    ("SinPower{6}",     SinPower{6}()),
-    ("SinPower{8}",     SinPower{8}()),
-    ("SmoothBoundary(5)",  SmoothBoundary(5)),
+    ("Uniform", Uniform()),
+    ("SSD", SSD()),
+    ("SinPower{4}", SinPower{4}()),
+    ("SinPower{6}", SinPower{6}()),
+    ("SinPower{8}", SinPower{8}()),
+    ("SmoothBoundary(5)", SmoothBoundary(5)),
     ("SmoothBoundary(10)", SmoothBoundary(10)),
     ("SmoothBoundary(20)", SmoothBoundary(20)),
 ]
 
 site_x = 1:L
-bond_x = 1:(L-1)
+bond_x = 1:(L - 1)
 
 # ---- site_weight ----
 p_site = plot(;
-    xlabel = "site index i",
-    ylabel = "site_weight(mod, i, L=$L)",
-    title  = "site weight envelopes (1D, L=$L)",
-    legend = :outerright,
-    size   = (900, 420),
-    framestyle = :box,
-    grid = true,
+    xlabel="site index i",
+    ylabel="site_weight(mod, i, L=$L)",
+    title="site weight envelopes (1D, L=$L)",
+    legend=:outerright,
+    size=(900, 420),
+    framestyle=:box,
+    grid=true,
 )
 for (name, m) in modulations
     ys = [site_weight(m, i, L) for i in site_x]
-    plot!(p_site, site_x, ys; label = name, lw = 2)
+    plot!(p_site, site_x, ys; label=name, lw=2)
 end
 
 # ---- bond_weight ----
 p_bond = plot(;
-    xlabel = "bond index i (bond connects i and i+1)",
-    ylabel = "bond_weight(mod, i, L=$L)",
-    title  = "bond weight envelopes (1D, L=$L)",
-    legend = :outerright,
-    size   = (900, 420),
-    framestyle = :box,
-    grid = true,
+    xlabel="bond index i (bond connects i and i+1)",
+    ylabel="bond_weight(mod, i, L=$L)",
+    title="bond weight envelopes (1D, L=$L)",
+    legend=:outerright,
+    size=(900, 420),
+    framestyle=:box,
+    grid=true,
 )
 for (name, m) in modulations
     ys = [bond_weight(m, i, L) for i in bond_x]
-    plot!(p_bond, bond_x, ys; label = name, lw = 2)
+    plot!(p_bond, bond_x, ys; label=name, lw=2)
 end
 
 # Combined panel.
-p_all = plot(p_site, p_bond; layout = (2, 1), size = (1000, 800))
+p_all = plot(p_site, p_bond; layout=(2, 1), size=(1000, 800))
 
 outdir = joinpath(@__DIR__, "out")
 mkpath(outdir)
 savefig(p_site, joinpath(outdir, "site_weight.png"))
 savefig(p_bond, joinpath(outdir, "bond_weight.png"))
-savefig(p_all,  joinpath(outdir, "combined.png"))
+savefig(p_all, joinpath(outdir, "combined.png"))
 println("Wrote: ", readdir(outdir))

--- a/examples/plot_modulation_2d_continuous.jl
+++ b/examples/plot_modulation_2d_continuous.jl
@@ -52,7 +52,8 @@ env_cyl_x(x, y) = ssd_axis(x, Lx)
 # the envelope reaches 0 on the inscribed circle and is identically
 # zero outside it (corners are dark).
 function env_sphere_inscribed(x, y)
-    cx = center(Lx); cy = center(Ly)
+    cx = center(Lx);
+    cy = center(Ly)
     d = sqrt((x - cx)^2 + (y - cy)^2)
     R = min(Lx, Ly) / 2
     profile_sin_square(d, R)
@@ -62,7 +63,8 @@ end
 # the envelope only reaches 0 at the corners; the four edge midpoints
 # carry a finite weight. This is what "spherical, no zero rim" looks like.
 function env_sphere_circumscribed(x, y)
-    cx = center(Lx); cy = center(Ly)
+    cx = center(Lx);
+    cy = center(Ly)
     d = sqrt((x - cx)^2 + (y - cy)^2)
     R = sqrt((Lx / 2)^2 + (Ly / 2)^2)
     profile_sin_square(d, R)
@@ -71,7 +73,8 @@ end
 # (5) Spherical SinPower{4}: sharper roll-off at the boundary, broader
 # central plateau (Hotta-Shibata flavour on a disk).
 function env_sphere_sinpow4(x, y)
-    cx = center(Lx); cy = center(Ly)
+    cx = center(Lx);
+    cy = center(Ly)
     d = sqrt((x - cx)^2 + (y - cy)^2)
     R = min(Lx, Ly) / 2
     profile_sin_power(d, R, 4)
@@ -80,7 +83,8 @@ end
 # (6) Spherical SmoothBoundary: flat-1 plateau in the bulk + half-cosine
 # ramp on the rim (Vekic-White on a disk).
 function env_sphere_smooth(x, y)
-    cx = center(Lx); cy = center(Ly)
+    cx = center(Lx);
+    cy = center(Ly)
     d = sqrt((x - cx)^2 + (y - cy)^2)
     R = min(Lx, Ly) / 2
     profile_smooth(d, R, 8)
@@ -88,37 +92,45 @@ end
 
 # ---- Build heatmaps -------------------------------------------------
 
-xs = range(0.5, Lx + 0.5; length = 200)
-ys = range(0.5, Ly + 0.5; length = 200)
+xs = range(0.5, Lx + 0.5; length=200)
+ys = range(0.5, Ly + 0.5; length=200)
 
 panels = [
-    ("Rectangular SSD\n(axis product)",                env_rect),
-    ("Cylindrical SSD (x-axial)\nuniform in y",         env_cyl_x),
-    ("Spherical SSD\ninscribed R = min(Lx,Ly)/2",       env_sphere_inscribed),
-    ("Spherical SSD\ncircumscribed R = ‖(Lx,Ly)‖/2",    env_sphere_circumscribed),
-    ("Spherical SinPower{4}\nR = min/2",                env_sphere_sinpow4),
-    ("Spherical SmoothBoundary\nR = min/2, edge = 8",   env_sphere_smooth),
+    ("Rectangular SSD\n(axis product)", env_rect),
+    ("Cylindrical SSD (x-axial)\nuniform in y", env_cyl_x),
+    ("Spherical SSD\ninscribed R = min(Lx,Ly)/2", env_sphere_inscribed),
+    ("Spherical SSD\ncircumscribed R = ‖(Lx,Ly)‖/2", env_sphere_circumscribed),
+    ("Spherical SinPower{4}\nR = min/2", env_sphere_sinpow4),
+    ("Spherical SmoothBoundary\nR = min/2, edge = 8", env_sphere_smooth),
 ]
 
 plts = []
 for (title, f) in panels
     Z = [f(x, y) for y in ys, x in xs]   # Z[j, i] = f(xs[i], ys[j])
-    p = heatmap(xs, ys, Z;
-        title  = title,
-        xlabel = "x",
-        ylabel = "y",
-        aspect_ratio = :equal,
-        c = :viridis,
-        clims  = (0.0, 1.0),
-        colorbar = false,
-        framestyle = :box,
+    p = heatmap(
+        xs,
+        ys,
+        Z;
+        title=title,
+        xlabel="x",
+        ylabel="y",
+        aspect_ratio=:equal,
+        c=:viridis,
+        clims=(0.0, 1.0),
+        colorbar=false,
+        framestyle=:box,
     )
     # Overlay a 0.5-level contour to make the falloff region visible.
-    contour!(p, xs, ys, Z; levels = [0.5], lc = :white, lw = 1.2)
+    contour!(p, xs, ys, Z; levels=[0.5], lc=:white, lw=1.2)
     push!(plts, p)
 end
 
-p_all = plot(plts...; layout = (3, 2), size = (1100, 1500), plot_title = "2D Modulation Envelopes (Lx=Ly=$Lx)")
+p_all = plot(
+    plts...;
+    layout=(3, 2),
+    size=(1100, 1500),
+    plot_title="2D Modulation Envelopes (Lx=Ly=$Lx)",
+)
 
 outdir = joinpath(@__DIR__, "out")
 mkpath(outdir)
@@ -127,20 +139,56 @@ println("Wrote: ", joinpath("out", "2d_continuous.png"))
 
 # Also dump a 1D radial cut through the disk envelopes so we can compare
 # the radial profiles directly.
-rs = range(0.0, min(Lx, Ly) / 2; length = 200)
+rs = range(0.0, min(Lx, Ly) / 2; length=200)
 p_radial = plot(;
-    xlabel = "distance from center r",
-    ylabel = "envelope(r)",
-    title  = "Radial profile cuts (R = min(Lx,Ly)/2 = $(min(Lx,Ly) ÷ 2))",
-    legend = :outerright,
-    framestyle = :box,
-    size   = (900, 420),
+    xlabel="distance from center r",
+    ylabel="envelope(r)",
+    title="Radial profile cuts (R = min(Lx,Ly)/2 = $(min(Lx,Ly) ÷ 2))",
+    legend=:outerright,
+    framestyle=:box,
+    size=(900, 420),
 )
-plot!(p_radial, rs, [profile_sin_square(r, min(Lx, Ly) / 2) for r in rs]; label = "SinSquare", lw = 2)
-plot!(p_radial, rs, [profile_sin_power(r, min(Lx, Ly) / 2, 4) for r in rs]; label = "SinPower{4}", lw = 2)
-plot!(p_radial, rs, [profile_sin_power(r, min(Lx, Ly) / 2, 8) for r in rs]; label = "SinPower{8}", lw = 2)
-plot!(p_radial, rs, [profile_smooth(r, min(Lx, Ly) / 2, 4) for r in rs]; label = "SmoothBoundary edge=4", lw = 2)
-plot!(p_radial, rs, [profile_smooth(r, min(Lx, Ly) / 2, 8) for r in rs]; label = "SmoothBoundary edge=8", lw = 2)
-plot!(p_radial, rs, [profile_smooth(r, min(Lx, Ly) / 2, 12) for r in rs]; label = "SmoothBoundary edge=12", lw = 2)
+plot!(
+    p_radial,
+    rs,
+    [profile_sin_square(r, min(Lx, Ly) / 2) for r in rs];
+    label="SinSquare",
+    lw=2,
+)
+plot!(
+    p_radial,
+    rs,
+    [profile_sin_power(r, min(Lx, Ly) / 2, 4) for r in rs];
+    label="SinPower{4}",
+    lw=2,
+)
+plot!(
+    p_radial,
+    rs,
+    [profile_sin_power(r, min(Lx, Ly) / 2, 8) for r in rs];
+    label="SinPower{8}",
+    lw=2,
+)
+plot!(
+    p_radial,
+    rs,
+    [profile_smooth(r, min(Lx, Ly) / 2, 4) for r in rs];
+    label="SmoothBoundary edge=4",
+    lw=2,
+)
+plot!(
+    p_radial,
+    rs,
+    [profile_smooth(r, min(Lx, Ly) / 2, 8) for r in rs];
+    label="SmoothBoundary edge=8",
+    lw=2,
+)
+plot!(
+    p_radial,
+    rs,
+    [profile_smooth(r, min(Lx, Ly) / 2, 12) for r in rs];
+    label="SmoothBoundary edge=12",
+    lw=2,
+)
 savefig(p_radial, joinpath(outdir, "2d_radial_profile.png"))
 println("Wrote: ", joinpath("out", "2d_radial_profile.png"))

--- a/examples/plot_modulation_honeycomb_scatter.jl
+++ b/examples/plot_modulation_honeycomb_scatter.jl
@@ -19,21 +19,31 @@ xs = [p[1] for p in ps]
 ys = [p[2] for p in ps]
 
 panels = [
-    ("spherical_ssd (inscribed)",     spherical_ssd(lat; radius=:inscribed)),
+    ("spherical_ssd (inscribed)", spherical_ssd(lat; radius=:inscribed)),
     ("spherical_ssd (circumscribed)", spherical_ssd(lat; radius=:circumscribed)),
-    ("spherical_ssd (N=4)",           spherical_ssd(lat; radius=:circumscribed, N=4)),
-    ("cylindrical_ssd (axis=1)",      cylindrical_ssd(lat; axis=1)),
-    ("cylindrical_ssd (axis=2)",      cylindrical_ssd(lat; axis=2)),
-    ("rectangular_ssd",               rectangular_ssd(lat)),
+    ("spherical_ssd (N=4)", spherical_ssd(lat; radius=:circumscribed, N=4)),
+    ("cylindrical_ssd (axis=1)", cylindrical_ssd(lat; axis=1)),
+    ("cylindrical_ssd (axis=2)", cylindrical_ssd(lat; axis=2)),
+    ("rectangular_ssd", rectangular_ssd(lat)),
 ]
 
 plts = []
 for (title, env) in panels
     ws = [ITensorModels.site_weight(env, lat, k) for k in 1:num_sites(lat)]
     p = scatter(
-        xs, ys; marker_z=ws, c=:viridis, ms=8, msw=0.4,
-        clims=(0.0, 1.0), aspect_ratio=:equal, title=title,
-        xlabel="x", ylabel="y", framestyle=:box, legend=false,
+        xs,
+        ys;
+        marker_z=ws,
+        c=:viridis,
+        ms=8,
+        msw=0.4,
+        clims=(0.0, 1.0),
+        aspect_ratio=:equal,
+        title=title,
+        xlabel="x",
+        ylabel="y",
+        framestyle=:box,
+        legend=false,
         colorbar=true,
     )
     # Overlay bond midpoints coloured by bond_weight for visual continuity.
@@ -48,7 +58,9 @@ for (title, env) in panels
 end
 
 p_all = plot(
-    plts...; layout=(3, 2), size=(1100, 1500),
+    plts...;
+    layout=(3, 2),
+    size=(1100, 1500),
     plot_title="ND modulation envelopes on honeycomb($L, $L) — site_weight scatter",
 )
 

--- a/ext/LatticeCoreExt.jl
+++ b/ext/LatticeCoreExt.jl
@@ -381,23 +381,17 @@ function ITensorModels.spherical_ssd(
     elseif radius === :circumscribed
         sqrt(sum(half .^ 2))
     else
-        error(
-            "spherical_ssd: radius must be :inscribed or :circumscribed " *
-            "(got :$radius)",
-        )
+        error("spherical_ssd: radius must be :inscribed or :circumscribed " * "(got :$radius)")
     end
     return RadialEnvelope(
         BoundingBoxCenter(), EuclideanDistance(), _make_profile(Val(N), R)
     )
 end
 
-function ITensorModels.cylindrical_ssd(
-    lat::AbstractLattice; axis::Int=1, N::Int=2
-)
+function ITensorModels.cylindrical_ssd(lat::AbstractLattice; axis::Int=1, N::Int=2)
     lo, hi = _bounding_extent(lat)
-    1 <= axis <= length(lo) || error(
-        "cylindrical_ssd: axis=$axis out of range [1, $(length(lo))]"
-    )
+    1 <= axis <= length(lo) ||
+        error("cylindrical_ssd: axis=$axis out of range [1, $(length(lo))]")
     R = (hi[axis] - lo[axis]) / 2
     return RadialEnvelope(
         BoundingBoxCenter(), AxialDistance(axis), _make_profile(Val(N), R)

--- a/src/ITensorModels.jl
+++ b/src/ITensorModels.jl
@@ -9,6 +9,7 @@ export bond_term, boundary_patch, local_ham_terms, build_opsum
 export bond_coupling_term, onsite_term
 export onsite_observable_op, build_onsite_observable_opsum
 export TFIM, TFIML, XXZ1D, Heisenberg1D, KitaevBond, LatticeModel
+export XYh1D
 export AbstractModulation, Uniform, SSD, SinPower, SmoothBoundary, Tabulated
 export site_weight, bond_weight
 export ModulatedModel, modulated
@@ -67,6 +68,7 @@ include("models/tfiml.jl")
 include("models/xxz.jl")
 include("models/heisenberg.jl")
 include("models/kitaev_bond.jl")
+include("models/xy_h_1d.jl")
 include("models/lattice_model.jl")
 include("models/modulated.jl")
 include("models/modulated_lattice.jl")

--- a/src/core/modulation_nd.jl
+++ b/src/core/modulation_nd.jl
@@ -206,7 +206,9 @@ function _validate_radius_positive(name::String, R)
         all(x -> x isa Real && x > 0, R) ||
             error("$name: every per-axis R entry must be a positive Real, got R=$R")
     else
-        error("$name: R must be a positive Real or an iterable of positive Reals, got typeof(R)=$(typeof(R))")
+        error(
+            "$name: R must be a positive Real or an iterable of positive Reals, got typeof(R)=$(typeof(R))",
+        )
     end
     return nothing
 end
@@ -277,7 +279,7 @@ struct CosineRampProfile{R,E} <: AbstractProfile
         # deferred so a vector R does not reach this constructor in practice.
         if r isa Real
             e <= r || error(
-                "CosineRampProfile: edge must satisfy 0 < edge <= R, got edge=$e, R=$r",
+                "CosineRampProfile: edge must satisfy 0 < edge <= R, got edge=$e, R=$r"
             )
         end
         return new{R,E}(r, e)

--- a/src/models/xy_h_1d.jl
+++ b/src/models/xy_h_1d.jl
@@ -1,0 +1,64 @@
+using ITensors: SiteType, @SiteType_str
+
+"""
+    XYh1D(; J=1.0, γ=0.0, h=0.0, site=SiteType("S=1/2"))
+
+1D anisotropic XY model in a transverse field (the canonical
+Lieb-Schultz-Mattis chain):
+
+    H = -J Σ_i [ (1+γ) S^x_i S^x_{i+1} + (1-γ) S^y_i S^y_{i+1} ]
+        - h Σ_i S^z_i
+
+on `SiteType("S=1/2")`. Special cases:
+
+- `γ = 0`: isotropic XX chain (free-fermion line via Jordan-Wigner).
+- `γ = 1`: equivalent to the transverse-field Ising chain.
+- `0 < γ < 1`: Ising universality class with a quantum phase transition
+  at `|h| / J = 1`.
+
+Exactly solvable by JW + Bogoliubov (Lieb, Schultz, Mattis 1961); useful
+benchmark for DMRG and quench dynamics.
+"""
+Base.@kwdef struct XYh1D <: AbstractLatticeModel
+    J::Float64 = 1.0
+    γ::Float64 = 0.0
+    h::Float64 = 0.0
+    site::SiteType = SiteType("S=1/2")
+end
+
+site_type(m::XYh1D) = m.site
+
+function bond_term(m::XYh1D, i::Int, j::Int)
+    H = OpSum()
+    H += -m.J * (1 + m.γ), "Sx", i, "Sx", j
+    H += -m.J * (1 - m.γ), "Sy", i, "Sy", j
+    H += -(m.h / 2), "Sz", i
+    H += -(m.h / 2), "Sz", j
+    return H
+end
+
+function boundary_patch(m::XYh1D, k::Int)
+    H = OpSum()
+    H += -(m.h / 2), "Sz", k
+    return H
+end
+
+function bond_coupling_term(m::XYh1D, i::Int, j::Int)
+    H = OpSum()
+    H += -m.J * (1 + m.γ), "Sx", i, "Sx", j
+    H += -m.J * (1 - m.γ), "Sy", i, "Sy", j
+    return H
+end
+
+function onsite_term(m::XYh1D, k::Int)
+    H = OpSum()
+    H += -m.h, "Sz", k
+    return H
+end
+
+function onsite_observable_op(::XYh1D, name::Symbol)
+    name === :sx && return "Sx"
+    name === :sy && return "Sy"
+    name === :sz && return "Sz"
+    return error("XYh1D: unsupported onsite observable $name")
+end

--- a/src/models/xy_h_1d.jl
+++ b/src/models/xy_h_1d.jl
@@ -11,10 +11,14 @@ Lieb-Schultz-Mattis chain):
 
 on `SiteType("S=1/2")`. Special cases:
 
-- `γ = 0`: isotropic XX chain (free-fermion line via Jordan-Wigner).
-- `γ = 1`: equivalent to the transverse-field Ising chain.
-- `0 < γ < 1`: Ising universality class with a quantum phase transition
-  at `|h| / J = 1`.
+- `γ = 0`: isotropic XX chain (free-fermion line via Jordan-Wigner; the
+  field `h` becomes a chemical potential on the JW fermions).
+- `γ = 1`: equivalent to the transverse-field Ising chain after a
+  global `π/2` spin rotation. Note that with `S = 1/2` operators
+  (`Sˣ = σˣ / 2`), the coupling reads `-J SˣSˣ = -(J/4) σˣσˣ`, so the
+  TFIM coupling in Pauli-operator conventions is `J/4`, not `J`.
+- `γ ≠ 0`: quantum phase transition at `|h| / J = 1` (Ising universality
+  class; the transition persists at `γ = 1`).
 
 Exactly solvable by JW + Bogoliubov (Lieb, Schultz, Mattis 1961); useful
 benchmark for DMRG and quench dynamics.

--- a/test/base/test_modulated_lattice.jl
+++ b/test/base/test_modulated_lattice.jl
@@ -7,15 +7,8 @@ using Test
 
 @testset "ModulatedLatticeModel: construction" begin
     lat = Lattice2D.honeycomb(4, 4; boundary=OpenAxis())
-    base = LatticeModel(;
-        lattice=lat,
-        bond_models=Dict(:nearest => Heisenberg1D(; J=1.0)),
-    )
-    env = RadialEnvelope(
-        BoundingBoxCenter(),
-        EuclideanDistance(),
-        SinSquareProfile(5.0),
-    )
+    base = LatticeModel(; lattice=lat, bond_models=Dict(:nearest => Heisenberg1D(; J=1.0)))
+    env = RadialEnvelope(BoundingBoxCenter(), EuclideanDistance(), SinSquareProfile(5.0))
     mod = modulated_lattice(base; envelope=env)
     @test mod isa ModulatedLatticeModel
     @test mod isa AbstractLatticeModel
@@ -26,13 +19,10 @@ end
 
 @testset "ModulatedLatticeModel: build_opsum on honeycomb" begin
     lat = Lattice2D.honeycomb(4, 4; boundary=OpenAxis())
-    base = LatticeModel(;
-        lattice=lat,
-        bond_models=Dict(:nearest => Heisenberg1D(; J=1.0)),
-    )
+    base = LatticeModel(; lattice=lat, bond_models=Dict(:nearest => Heisenberg1D(; J=1.0)))
     ps = collect(LatticeCore.positions(lat))
     rc = ITensorModels.center_position(BoundingBoxCenter(), lat)
-    R = sqrt(maximum(sum((p .- rc).^2) for p in ps)) + 0.5
+    R = sqrt(maximum(sum((p .- rc) .^ 2) for p in ps)) + 0.5
     env = RadialEnvelope(BoundingBoxCenter(), EuclideanDistance(), SinSquareProfile(R))
     mod = modulated_lattice(base; envelope=env)
 
@@ -52,9 +42,8 @@ end
     H_ref = OpSum()
     for b in bonds(lat)
         fb = ITensorModels.bond_weight(env, lat, b.i, b.j)
-        H_ref += fb * ITensorModels.bond_coupling_term(
-            Heisenberg1D(; J=1.0), ord[b.i], ord[b.j]
-        )
+        H_ref +=
+            fb * ITensorModels.bond_coupling_term(Heisenberg1D(; J=1.0), ord[b.i], ord[b.j])
     end
     ref_terms = collect(ITensors.terms(H_ref))
     @test length(ref_terms) > 0
@@ -73,7 +62,7 @@ end
     lat = Lattice2D.honeycomb(4, 4; boundary=OpenAxis())
     ps = collect(LatticeCore.positions(lat))
     rc = ITensorModels.center_position(BoundingBoxCenter(), lat)
-    R_huge = 1000 * sqrt(maximum(sum((p .- rc).^2) for p in ps))
+    R_huge = 1000 * sqrt(maximum(sum((p .- rc) .^ 2) for p in ps))
     env = RadialEnvelope(BoundingBoxCenter(), EuclideanDistance(), SinSquareProfile(R_huge))
 
     for b in bonds(lat)
@@ -91,14 +80,14 @@ end
     lat = Lattice2D.honeycomb(6, 6; boundary=OpenAxis())
     ps = collect(LatticeCore.positions(lat))
     rc = ITensorModels.center_position(BoundingBoxCenter(), lat)
-    R = sqrt(maximum(sum((p .- rc).^2) for p in ps))
+    R = sqrt(maximum(sum((p .- rc) .^ 2) for p in ps))
     env = RadialEnvelope(BoundingBoxCenter(), EuclideanDistance(), SinSquareProfile(R))
 
     bs = collect(bonds(lat))
     w_corner = ITensorModels.bond_weight(env, lat, bs[1].i, bs[1].j)
 
     midpoints = [(position(lat, b.i) + position(lat, b.j)) / 2 for b in bs]
-    distances = [sqrt(sum((mid .- rc).^2)) for mid in midpoints]
+    distances = [sqrt(sum((mid .- rc) .^ 2)) for mid in midpoints]
     k_central = argmin(distances)
     w_centre = ITensorModels.bond_weight(env, lat, bs[k_central].i, bs[k_central].j)
 
@@ -113,13 +102,10 @@ end
     # count (which would be all we'd get if onsite emission were
     # missing).
     lat = Lattice2D.honeycomb(4, 4; boundary=OpenAxis())
-    base = LatticeModel(;
-        lattice=lat,
-        bond_models=Dict(:nearest => TFIM(; J=1.0, h=0.5)),
-    )
+    base = LatticeModel(; lattice=lat, bond_models=Dict(:nearest => TFIM(; J=1.0, h=0.5)))
     ps = collect(LatticeCore.positions(lat))
     rc = ITensorModels.center_position(BoundingBoxCenter(), lat)
-    R_huge = 1000 * sqrt(maximum(sum((p .- rc).^2) for p in ps))
+    R_huge = 1000 * sqrt(maximum(sum((p .- rc) .^ 2) for p in ps))
     env = RadialEnvelope(BoundingBoxCenter(), EuclideanDistance(), SinSquareProfile(R_huge))
     mod = modulated_lattice(base; envelope=env)
 

--- a/test/base/test_modulation_nd_1d_equivalence.jl
+++ b/test/base/test_modulation_nd_1d_equivalence.jl
@@ -21,9 +21,7 @@ using Test
     # BoundingBoxCenter at (L+1)/2) with SinSquareProfile(L/2) is
     # designed to match the 1D SSD weights exactly.
     lat = LineLattice(L, OpenAxis())
-    env = RadialEnvelope(
-        BoundingBoxCenter(), AxialDistance(1), SinSquareProfile(L / 2)
-    )
+    env = RadialEnvelope(BoundingBoxCenter(), AxialDistance(1), SinSquareProfile(L / 2))
 
     # site_weight on ND ≡ 1D site_weight(SSD, k, L).
     for k in 1:L
@@ -55,13 +53,8 @@ end
 
     # ND path: LineLattice + LatticeModel(TFIM) + RadialEnvelope.
     lat = LineLattice(L, OpenAxis())
-    base_nd = LatticeModel(;
-        lattice=lat,
-        bond_models=Dict(:nearest => TFIM(; J=J, h=h)),
-    )
-    env = RadialEnvelope(
-        BoundingBoxCenter(), AxialDistance(1), SinSquareProfile(L / 2)
-    )
+    base_nd = LatticeModel(; lattice=lat, bond_models=Dict(:nearest => TFIM(; J=J, h=h)))
+    env = RadialEnvelope(BoundingBoxCenter(), AxialDistance(1), SinSquareProfile(L / 2))
     mod_nd = modulated_lattice(base_nd; envelope=env)
     H_nd_opsum = build_opsum(mod_nd, sites)
     MPO_nd = MPO(H_nd_opsum, sites)
@@ -88,18 +81,15 @@ end
     sites = siteinds("S=1/2", L)
 
     lat = LineLattice(L, OpenAxis())
-    base_nd = LatticeModel(;
-        lattice=lat,
-        bond_models=Dict(:nearest => TFIM(; J=J, h=h)),
-    )
-    env = RadialEnvelope(
-        BoundingBoxCenter(), AxialDistance(1), SinSquareProfile(1000 * L)
-    )
+    base_nd = LatticeModel(; lattice=lat, bond_models=Dict(:nearest => TFIM(; J=J, h=h)))
+    env = RadialEnvelope(BoundingBoxCenter(), AxialDistance(1), SinSquareProfile(1000 * L))
     mod_nd = modulated_lattice(base_nd; envelope=env)
     MPO_nd_huge = MPO(build_opsum(mod_nd, sites), sites)
 
     mod_uniform = modulated(TFIM(; J=J, h=h); L=L, modulation=Uniform())
-    MPO_uniform = MPO(build_opsum(mod_uniform, sites; phys_sites=1:L, boundary=:full), sites)
+    MPO_uniform = MPO(
+        build_opsum(mod_uniform, sites; phys_sites=1:L, boundary=:full), sites
+    )
 
     rng = MersenneTwister(0x9c1f)
     for trial in 1:3

--- a/test/base/test_modulation_nd_factories.jl
+++ b/test/base/test_modulation_nd_factories.jl
@@ -16,7 +16,7 @@ using Test
     # site_weight clips to 0 there.
     ps = collect(LatticeCore.positions(lat))
     rc = ITensorModels.center_position(BoundingBoxCenter(), lat)
-    k_corner = argmax([sqrt(sum((p .- rc).^2)) for p in ps])
+    k_corner = argmax([sqrt(sum((p .- rc) .^ 2)) for p in ps])
     @test ITensorModels.site_weight(env_in, lat, k_corner) ≈ 0.0 atol = 1e-12
 end
 
@@ -27,7 +27,7 @@ end
     @test env_out.profile isa SinSquareProfile
     ps = collect(LatticeCore.positions(lat))
     rc = ITensorModels.center_position(BoundingBoxCenter(), lat)
-    distances = [sqrt(sum((p .- rc).^2)) for p in ps]
+    distances = [sqrt(sum((p .- rc) .^ 2)) for p in ps]
     d_max = maximum(distances)
     for k in 1:num_sites(lat)
         w = ITensorModels.site_weight(env_out, lat, k)
@@ -97,7 +97,7 @@ end
 
     ps = collect(LatticeCore.positions(lat))
     rc = ITensorModels.center_position(BoundingBoxCenter(), lat)
-    k_central = argmin([sqrt(sum((p .- rc).^2)) for p in ps])
+    k_central = argmin([sqrt(sum((p .- rc) .^ 2)) for p in ps])
     @test 0.0 <= ITensorModels.site_weight(env, lat, k_central) <= 1.0
     @test ITensorModels.site_weight(env, lat, k_central) >= 0.85
 end

--- a/test/base/test_modulation_nd_validation.jl
+++ b/test/base/test_modulation_nd_validation.jl
@@ -88,9 +88,7 @@ end
 
 @testset "RadialEnvelope: CosineRampProfile + AxisProductDistance unsupported" begin
     @test_throws ErrorException RadialEnvelope(
-        BoundingBoxCenter(),
-        AxisProductDistance(),
-        CosineRampProfile(5.0, 1.0),
+        BoundingBoxCenter(), AxisProductDistance(), CosineRampProfile(5.0, 1.0)
     )
 end
 
@@ -143,8 +141,7 @@ end
     lat = Lattice2D.honeycomb(6, 6; boundary=OpenAxis())
     ps = collect(LatticeCore.positions(lat))
     Ry = maximum(
-        abs(p[2] - ITensorModels.center_position(BoundingBoxCenter(), lat)[2])
-        for p in ps
+        abs(p[2] - ITensorModels.center_position(BoundingBoxCenter(), lat)[2]) for p in ps
     )
     env = RadialEnvelope(
         BoundingBoxCenter(), PerpendicularDistance(1), SinSquareProfile(Ry)

--- a/test/base/test_xy_h_1d.jl
+++ b/test/base/test_xy_h_1d.jl
@@ -1,0 +1,75 @@
+using ITensorModels
+using ITensors
+using ITensors: SiteType
+using ITensorMPS
+using Random
+using Test
+
+@testset "XYh1D: construction" begin
+    m = XYh1D()
+    @test m isa AbstractLatticeModel
+    @test m.J == 1.0
+    @test m.γ == 0.0
+    @test m.h == 0.0
+    @test site_type(m) == SiteType("S=1/2")
+end
+
+@testset "XYh1D: bond_coupling_term has 2 (XX + YY)" begin
+    m = XYh1D(; J=1.0, γ=0.3, h=0.5)
+    H = bond_coupling_term(m, 1, 2)
+    @test length(collect(ITensors.terms(H))) == 2
+end
+
+@testset "XYh1D: onsite_term -h Sz" begin
+    m = XYh1D(; J=1.0, γ=0.0, h=0.7)
+    H = onsite_term(m, 3)
+    terms = collect(ITensors.terms(H))
+    @test length(terms) == 1
+    @test ITensors.coefficient(terms[1]) ≈ -0.7
+end
+
+@testset "XYh1D: onsite_observable_op" begin
+    m = XYh1D()
+    @test onsite_observable_op(m, :sx) == "Sx"
+    @test onsite_observable_op(m, :sy) == "Sy"
+    @test onsite_observable_op(m, :sz) == "Sz"
+    @test_throws ErrorException onsite_observable_op(m, :bogus)
+end
+
+@testset "XYh1D: build_opsum + ModulatedModel smoke" begin
+    L = 6
+    m = XYh1D(; J=1.0, γ=0.5, h=0.3)
+    m_ssd = modulated(m; L=L, modulation=SSD())
+    sites = siteinds("S=1/2", L)
+    H = build_opsum(m_ssd, sites; phys_sites=1:L, boundary=:full)
+    @test length(collect(ITensors.terms(H))) > 0
+end
+
+@testset "XYh1D: γ=0 XX limit DMRG smoke" begin
+    N = 6
+    m = XYh1D(; J=1.0, γ=0.0, h=0.0)
+    sites = siteinds("S=1/2", N)
+    H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
+    psi0 = random_mps(MersenneTwister(0x7a), sites; linkdims=12)
+    sweeps = Sweeps(15)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
+        200, 200, 200, 200, 200)
+    cutoff!(sweeps, 1e-12)
+    E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
+    @test isfinite(E)
+    @test E < 0
+end
+
+@testset "XYh1D: γ=1 TFIM-like DMRG smoke" begin
+    N = 6
+    m = XYh1D(; J=1.0, γ=1.0, h=0.5)
+    sites = siteinds("S=1/2", N)
+    H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
+    psi0 = random_mps(MersenneTwister(0x7b), sites; linkdims=12)
+    sweeps = Sweeps(15)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
+        200, 200, 200, 200, 200)
+    cutoff!(sweeps, 1e-12)
+    E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
+    @test isfinite(E)
+end

--- a/test/base/test_xy_h_1d.jl
+++ b/test/base/test_xy_h_1d.jl
@@ -52,8 +52,7 @@ end
     H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
     psi0 = random_mps(MersenneTwister(0x7a), sites; linkdims=12)
     sweeps = Sweeps(15)
-    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
-        200, 200, 200, 200, 200)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200)
     cutoff!(sweeps, 1e-12)
     E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
     @test isfinite(E)
@@ -67,8 +66,7 @@ end
     H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
     psi0 = random_mps(MersenneTwister(0x7b), sites; linkdims=12)
     sweeps = Sweeps(15)
-    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
-        200, 200, 200, 200, 200)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200)
     cutoff!(sweeps, 1e-12)
     E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
     @test isfinite(E)

--- a/test/base/test_xy_h_1d.jl
+++ b/test/base/test_xy_h_1d.jl
@@ -20,6 +20,31 @@ end
     @test length(collect(ITensors.terms(H))) == 2
 end
 
+@testset "XYh1D: bond_term coefficients (split-protocol)" begin
+    # With h ≠ 0 the bond_term must carry the two-body coupling at full
+    # value plus a half-edge -h/2 Sz on each endpoint, so that summing
+    # over interior bonds gives the right -h Sz per site and the OBC
+    # endpoints are completed by boundary_patch.
+    J, γ, h = 1.0, 0.3, 0.5
+    m = XYh1D(; J=J, γ=γ, h=h)
+    H = bond_term(m, 1, 2)
+    coefs = Float64[]
+    for t in ITensors.terms(H)
+        push!(coefs, ITensors.coefficient(t))
+    end
+    # Expected (order-independent): -J(1+γ), -J(1-γ), -h/2, -h/2
+    expected = sort([-J * (1 + γ), -J * (1 - γ), -h / 2, -h / 2])
+    @test sort(coefs) ≈ expected
+end
+
+@testset "XYh1D: boundary_patch is -h/2 Sz" begin
+    m = XYh1D(; J=1.0, γ=0.0, h=0.4)
+    H = boundary_patch(m, 1)
+    terms = collect(ITensors.terms(H))
+    @test length(terms) == 1
+    @test ITensors.coefficient(terms[1]) ≈ -0.2
+end
+
 @testset "XYh1D: onsite_term -h Sz" begin
     m = XYh1D(; J=1.0, γ=0.0, h=0.7)
     H = onsite_term(m, 3)
@@ -70,4 +95,5 @@ end
     cutoff!(sweeps, 1e-12)
     E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
     @test isfinite(E)
+    @test E < 0
 end


### PR DESCRIPTION
## Summary

Add **XYh1D** — 1D anisotropic XY chain in a transverse field (Lieb–Schultz–Mattis 1961):

```
H = -J Σ_i [(1+γ) Sx_i Sx_{i+1} + (1-γ) Sy_i Sy_{i+1}]
    - h Σ_i Sz_i
```

on `SiteType("S=1/2")`. Limits:
- `γ=0`: free-fermion XX chain (Jordan-Wigner).
- `γ=1`: transverse-field Ising chain.
- `0 < γ < 1`: Ising universality, QPT at `|h|/J = 1`.

Exact-solvable benchmark for DMRG and quench dynamics.

## Design

- Standard NN bond + on-site split with half-edge convention.
- `bond_term`: 2 (XX, YY) couplings + 2 half-edge `-h/2 Sz`.
- `boundary_patch`: missing-bond `-h/2 Sz`.
- `bond_coupling_term`: 2 (pure two-body).
- `onsite_term`: `-h Sz`.
- Project.toml: 0.6.8 → 0.7.0.

## Test plan

- [x] Construction defaults (J=1, γ=0, h=0, SiteType("S=1/2"))
- [x] `bond_coupling_term` has 2 terms (XX + YY)
- [x] `onsite_term` emits -h Sz with correct coefficient
- [x] `onsite_observable_op` lookup + error path
- [x] `build_opsum` + ModulatedModel SSD smoke
- [x] γ=0 XX-limit DMRG (finite negative GS)
- [x] γ=1 TFIM-limit DMRG smoke
