### PR TITLE
chore(recover): QAtlas bridge for S1Heisenberg1D (recover #40 onto main)

### DIFF
--- a/ext/QAtlasExt.jl
+++ b/ext/QAtlasExt.jl
@@ -62,6 +62,22 @@ function ITensorModels.from_qatlas(::QAtlas.Heisenberg1D)
     return ITensorModels.Heisenberg1D()
 end
 
+# --- S1Heisenberg1D ----------------------------------------------------
+
+function ITensorModels.to_qatlas(m::ITensorModels.S1Heisenberg1D)
+    ITensorModels.to_qatlas(m, m.site)
+end
+
+# QAtlas.S1Heisenberg1D uses the same J coefficient on spin-1 Sx/Sy/Sz
+# matrices (eigenvalues -1, 0, +1) -- no rescaling needed.
+function ITensorModels.to_qatlas(m::ITensorModels.S1Heisenberg1D, ::SiteType"S=1")
+    return QAtlas.S1Heisenberg1D(; J=m.J)
+end
+
+function ITensorModels.from_qatlas(qm::QAtlas.S1Heisenberg1D)
+    return ITensorModels.S1Heisenberg1D(; J=qm.J)
+end
+
 # --- fetch forwarder ----------------------------------------------------
 #
 # Route `QAtlas.fetch` calls that take an ITensorModels model through

--- a/test/base/test_compass_1d.jl
+++ b/test/base/test_compass_1d.jl
@@ -53,8 +53,7 @@ end
     H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
     psi0 = random_mps(MersenneTwister(0xc2), sites; linkdims=12)
     sweeps = Sweeps(15)
-    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
-        200, 200, 200, 200, 200)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200)
     cutoff!(sweeps, 1e-12)
     E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
     @test isfinite(E)

--- a/test/base/test_extended_hubbard_1d.jl
+++ b/test/base/test_extended_hubbard_1d.jl
@@ -54,8 +54,7 @@ end
     H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
     psi0 = random_mps(MersenneTwister(0xfa), sites; linkdims=12)
     sweeps = Sweeps(15)
-    maxdim!(sweeps, 20, 50, 100, 200, 200, 200, 200, 200, 200, 200,
-        200, 200, 200, 200, 200)
+    maxdim!(sweeps, 20, 50, 100, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200)
     cutoff!(sweeps, 1e-12)
     E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
     @test isfinite(E)
@@ -68,8 +67,7 @@ end
     H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
     psi0 = random_mps(MersenneTwister(0xfb), sites; linkdims=12)
     sweeps = Sweeps(15)
-    maxdim!(sweeps, 20, 50, 100, 200, 200, 200, 200, 200, 200, 200,
-        200, 200, 200, 200, 200)
+    maxdim!(sweeps, 20, 50, 100, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200)
     cutoff!(sweeps, 1e-12)
     E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
     @test isfinite(E)

--- a/test/base/test_heisenberg_s1.jl
+++ b/test/base/test_heisenberg_s1.jl
@@ -28,8 +28,7 @@ end
     m = S1Heisenberg1D(; J=0.8)
     H_bond = bond_term(m, 3, 4)
     H_coup = bond_coupling_term(m, 3, 4)
-    @test length(collect(ITensors.terms(H_bond))) ==
-        length(collect(ITensors.terms(H_coup)))
+    @test length(collect(ITensors.terms(H_bond))) == length(collect(ITensors.terms(H_coup)))
     @test length(collect(ITensors.terms(onsite_term(m, 1)))) == 0
 end
 

--- a/test/base/test_long_range_ising_1d.jl
+++ b/test/base/test_long_range_ising_1d.jl
@@ -59,8 +59,7 @@ end
     H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
     psi0 = random_mps(MersenneTwister(0xdf), sites; linkdims=12)
     sweeps = Sweeps(15)
-    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
-        200, 200, 200, 200, 200)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200)
     cutoff!(sweeps, 1e-12)
     E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
     @test isfinite(E)

--- a/test/base/test_qatlas_bridge.jl
+++ b/test/base/test_qatlas_bridge.jl
@@ -139,3 +139,70 @@ end
     @test real(inner(ψ_s_up', H_s, ψ_s_up)) ≈ expected rtol = 1e-12
     @test real(inner(ψ_q_up', H_q, ψ_q_up)) ≈ expected rtol = 1e-12
 end
+
+@testset "S1Heisenberg1D bridge: to_qatlas + round-trip" begin
+    m = S1Heisenberg1D(; J=1.3)
+    qm = to_qatlas(m)
+    @test qm isa QAtlas.S1Heisenberg1D
+    @test qm.J ≈ 1.3
+    back = from_qatlas(qm)
+    @test back isa S1Heisenberg1D
+    @test back.J ≈ 1.3
+end
+
+@testset "S1Heisenberg1D: forwarder routes Energy fetch through QAtlas" begin
+    # Compare the forwarded fetch on the ITensorModels struct against a
+    # direct fetch on a hand-built QAtlas struct -- they must agree
+    # bitwise modulo float rounding.
+    m = S1Heisenberg1D(; J=1.0)
+    qm_direct = QAtlas.S1Heisenberg1D(; J=1.0)
+    N = 6
+    @test QAtlas.fetch(m, Energy(), OBC(N); beta=10.0) ≈
+        QAtlas.fetch(qm_direct, Energy(), OBC(N); beta=10.0) rtol = 1e-12
+end
+
+@testset "S1Heisenberg1D: DMRG GS energy matches QAtlas dense ED (low-T limit)" begin
+    # High-beta thermal energy from QAtlas dense ED is the ground-state
+    # energy. Compare against DMRG on the same OBC chain.
+    using ITensorMPS
+    using Random
+    using ITensors: MPO, siteinds
+    using ITensorMPS: random_mps, dmrg, Sweeps, maxdim!, cutoff!
+
+    N = 6
+    J = 1.0
+    m = S1Heisenberg1D(; J=J)
+    E_qatlas = QAtlas.fetch(m, Energy(), OBC(N); beta=50.0)
+
+    sites = siteinds("S=1", N)
+    H = MPO(ITensorModels.build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
+    psi0 = random_mps(MersenneTwister(0x51), sites; linkdims=8)
+    sweeps = Sweeps(20)
+    maxdim!(
+        sweeps,
+        10,
+        20,
+        40,
+        60,
+        80,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+        100,
+    )
+    cutoff!(sweeps, 1e-12)
+    E_dmrg, _ = dmrg(H, psi0, sweeps; outputlevel=0)
+
+    @test E_dmrg ≈ E_qatlas rtol = 1e-5
+end


### PR DESCRIPTION
## Summary

Recovery PR for **#40 (QAtlas bridge: S1Heisenberg1D)**.

#40 was originally opened with the wrong base (`feat/s1-heisenberg` instead of `main`); when it was merged the bridge content landed on the orphan parent branch, **not on main**. The orphan branch has now been deleted, and this PR cherry-picks the same content onto main so the QAtlas bridge ships in `v0.7.0`.

Content identical to the original #40 squash (`05f1d586`), with `Project.toml` kept at `0.7.0` (already where main is).

## Test plan

Already verified on the original PR #40 CI (success at run 25731626314). The bridge is purely additive; no API change.
