### PR TITLE
feat(models): add SSH1D (Su-Schrieffer-Heeger topological chain)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.7.10"
+version = "0.7.13"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/ITensorModels.jl
+++ b/src/ITensorModels.jl
@@ -21,6 +21,7 @@ export BoseHubbard1D
 export DMIHeisenberg1D
 export LongRangeXY1D
 export PXP1D
+export SSH1D
 export TFIM, TFIML, XXZ1D, Heisenberg1D, S1Heisenberg1D, KitaevBond, LatticeModel
 export TFIM, TFIML, XXZ1D, Heisenberg1D, KitaevBond, TightBinding1D, LatticeModel
 export AbstractModulation, Uniform, SSD, SinPower, SmoothBoundary, Tabulated
@@ -89,6 +90,7 @@ include("models/bose_hubbard_1d.jl")
 include("models/dmi_heisenberg_1d.jl")
 include("models/long_range_xy_1d.jl")
 include("models/pxp_1d.jl")
+include("models/ssh_1d.jl")
 include("models/kitaev_bond.jl")
 include("models/xy_h_1d.jl")
 include("models/long_range_ising_1d.jl")

--- a/src/models/ssh_1d.jl
+++ b/src/models/ssh_1d.jl
@@ -1,0 +1,48 @@
+using ITensors: SiteType, @SiteType_str
+
+"""
+    SSH1D(; t1=0.8, t2=1.0, site=SiteType("Fermion"))
+
+Su-Schrieffer-Heeger (SSH) chain for spinless fermions:
+
+    H = -t1 sum_{i odd}  (c+_i c_{i+1} + h.c.)
+        -t2 sum_{i even} (c+_i c_{i+1} + h.c.)
+
+Paradigmatic 1D topological insulator (symmetry class BDI).
+- Topological phase: |t2| > |t1| -- zero-energy edge modes at OBC.
+- Trivial phase:     |t2| < |t1| -- fully gapped, no edge modes.
+- Critical point:    |t2| = |t1| -- gapless (massless Dirac fermion).
+
+Overrides local_ham_terms because the hopping amplitude alternates
+with bond parity (odd bonds carry t1, even bonds carry t2).
+"""
+Base.@kwdef struct SSH1D <: AbstractLatticeModel
+    t1::Float64 = 0.8
+    t2::Float64 = 1.0
+    site::SiteType = SiteType("Fermion")
+end
+
+site_type(m::SSH1D) = m.site
+
+bond_term(::SSH1D, ::Int, ::Int) = OpSum()
+bond_coupling_term(::SSH1D, ::Int, ::Int) = OpSum()
+onsite_term(::SSH1D, ::Int) = OpSum()
+
+function onsite_observable_op(::SSH1D, name::Symbol)
+    name === :n && return "N"
+    return error("SSH1D: unsupported onsite observable $name")
+end
+
+function local_ham_terms(m::SSH1D, phys_sites; boundary::Symbol=:bulk_half_edge)
+    phys = collect(phys_sites)
+    N = length(phys)
+    terms = OpSum[]
+    for i in 1:(N - 1)
+        H = OpSum()
+        t = isodd(i) ? m.t1 : m.t2
+        H += -t, "Cdag", phys[i], "C", phys[i + 1]
+        H += -t, "Cdag", phys[i + 1], "C", phys[i]
+        push!(terms, H)
+    end
+    return terms
+end

--- a/test/base/test_ssh_1d.jl
+++ b/test/base/test_ssh_1d.jl
@@ -54,8 +54,7 @@ end
     psi0 = MPS(sites, state)
     H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
     sweeps = Sweeps(15)
-    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
-        200, 200, 200, 200, 200)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200)
     cutoff!(sweeps, 1e-12)
     E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
     @test isfinite(E)
@@ -70,8 +69,7 @@ end
     psi0 = MPS(sites, state)
     H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
     sweeps = Sweeps(15)
-    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
-        200, 200, 200, 200, 200)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200)
     cutoff!(sweeps, 1e-12)
     E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
     @test isfinite(E)

--- a/test/base/test_ssh_1d.jl
+++ b/test/base/test_ssh_1d.jl
@@ -1,0 +1,79 @@
+using ITensorModels
+using ITensors
+using ITensors: SiteType
+using ITensorMPS
+using Random
+using Test
+
+@testset "SSH1D: construction" begin
+    m = SSH1D()
+    @test m isa AbstractLatticeModel
+    @test m.t1 == 0.8
+    @test m.t2 == 1.0
+    @test site_type(m) == SiteType("Fermion")
+end
+
+@testset "SSH1D: pairwise / onsite all empty" begin
+    m = SSH1D(; t1=0.8, t2=1.2)
+    @test length(collect(ITensors.terms(bond_term(m, 1, 2)))) == 0
+    @test length(collect(ITensors.terms(bond_coupling_term(m, 1, 2)))) == 0
+    @test length(collect(ITensors.terms(onsite_term(m, 1)))) == 0
+end
+
+@testset "SSH1D: local_ham_terms alternates t1/t2" begin
+    N = 5
+    m = SSH1D(; t1=0.7, t2=1.3)
+    terms = local_ham_terms(m, 1:N; boundary=:full)
+    @test length(terms) == N - 1
+    for (i, t) in enumerate(terms)
+        coefs = [ITensors.coefficient(x) for x in ITensors.terms(t)]
+        expected = isodd(i) ? -m.t1 : -m.t2
+        @test all(c ≈ expected for c in coefs)
+    end
+end
+
+@testset "SSH1D: build_opsum term count" begin
+    N = 6
+    m = SSH1D(; t1=0.5, t2=1.0)
+    sites = siteinds("Fermion", N; conserve_nf=false)
+    H = build_opsum(m, sites; phys_sites=1:N, boundary=:full)
+    @test length(collect(ITensors.terms(H))) == 2 * (N - 1)
+end
+
+@testset "SSH1D: onsite_observable_op" begin
+    m = SSH1D()
+    @test onsite_observable_op(m, :n) == "N"
+    @test_throws ErrorException onsite_observable_op(m, :bogus)
+end
+
+@testset "SSH1D: topological DMRG smoke (half-filling, t2 > t1)" begin
+    N = 6
+    m = SSH1D(; t1=0.5, t2=1.0)
+    sites = siteinds("Fermion", N; conserve_nf=true)
+    state = [isodd(i) ? "Occ" : "Emp" for i in 1:N]
+    psi0 = MPS(sites, state)
+    H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
+    sweeps = Sweeps(15)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
+        200, 200, 200, 200, 200)
+    cutoff!(sweeps, 1e-12)
+    E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
+    @test isfinite(E)
+    @test E < 0
+end
+
+@testset "SSH1D: trivial DMRG smoke (t1 > t2)" begin
+    N = 6
+    m = SSH1D(; t1=1.0, t2=0.5)
+    sites = siteinds("Fermion", N; conserve_nf=true)
+    state = [isodd(i) ? "Occ" : "Emp" for i in 1:N]
+    psi0 = MPS(sites, state)
+    H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
+    sweeps = Sweeps(15)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
+        200, 200, 200, 200, 200)
+    cutoff!(sweeps, 1e-12)
+    E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
+    @test isfinite(E)
+    @test E < 0
+end


### PR DESCRIPTION
Adds SSH1D — the paradigmatic 1D topological insulator for spinless fermions with alternating hoppings t1/t2. Overrides local_ham_terms for bond-parity-dependent hopping. Tests cover construction, alternation, term count, and DMRG smoke for both topological (t2>t1) and trivial (t1>t2) phases.