### PR TITLE
feat(models): add S1XXZ1D (S=1 XXZ anisotropic chain)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.7.13"
+version = "0.7.14"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/ITensorModels.jl
+++ b/src/ITensorModels.jl
@@ -23,6 +23,7 @@ export LongRangeXY1D
 export S1AnisotropicD1D
 export PXP1D
 export SSH1D
+export S1XXZ1D
 export Cluster1D
 export TFIM, TFIML, XXZ1D, Heisenberg1D, S1Heisenberg1D, KitaevBond, LatticeModel
 export TFIM, TFIML, XXZ1D, Heisenberg1D, KitaevBond, TightBinding1D, LatticeModel
@@ -94,6 +95,7 @@ include("models/long_range_xy_1d.jl")
 include("models/s1_anisotropic_d.jl")
 include("models/pxp_1d.jl")
 include("models/ssh_1d.jl")
+include("models/s1_xxz_1d.jl")
 include("models/cluster_1d.jl")
 include("models/kitaev_bond.jl")
 include("models/xy_h_1d.jl")

--- a/src/models/s1_xxz_1d.jl
+++ b/src/models/s1_xxz_1d.jl
@@ -1,0 +1,49 @@
+using ITensors: SiteType, @SiteType_str
+
+"""
+    S1XXZ1D(; J=1.0, Delta=1.0, site=SiteType("S=1"))
+
+S=1 XXZ Heisenberg chain:
+
+    H = J sum_i [Sx_i Sx_{i+1} + Sy_i Sy_{i+1} + Delta Sz_i Sz_{i+1}]
+
+Phase diagram (Schulz 1986):
+- : isotropic S=1 Heisenberg; gapped Haldane phase (SPT).
+- Large : easy-axis Neel phase (Ising-like ordering).
+- : pure XY chain on S=1; gapless.
+- : easy-plane / ferromagnetic tendency.
+
+The Haldane phase is robust for approximately -1 < Delta < infinity
+(exact bounds depend on additional terms). Generalises S1Heisenberg1D
+to tunable exchange anisotropy.
+"""
+Base.@kwdef struct S1XXZ1D <: AbstractLatticeModel
+    J::Float64 = 1.0
+    Delta::Float64 = 1.0
+    site::SiteType = SiteType("S=1")
+end
+
+site_type(m::S1XXZ1D) = m.site
+
+function bond_term(m::S1XXZ1D, i::Int, j::Int)
+    H = OpSum()
+    H += m.J, "Sx", i, "Sx", j
+    H += m.J, "Sy", i, "Sy", j
+    H += m.J * m.Delta, "Sz", i, "Sz", j
+    return H
+end
+
+boundary_patch(::S1XXZ1D, ::Int) = OpSum()
+
+function bond_coupling_term(m::S1XXZ1D, i::Int, j::Int)
+    return bond_term(m, i, j)
+end
+
+onsite_term(::S1XXZ1D, ::Int) = OpSum()
+
+function onsite_observable_op(::S1XXZ1D, name::Symbol)
+    name === :sx && return "Sx"
+    name === :sy && return "Sy"
+    name === :sz && return "Sz"
+    return error("S1XXZ1D: unsupported onsite observable $name")
+end

--- a/test/base/test_s1_xxz_1d.jl
+++ b/test/base/test_s1_xxz_1d.jl
@@ -22,7 +22,7 @@ end
 @testset "S1XXZ1D: Delta=1 all coefficients equal J" begin
     m = S1XXZ1D(; J=1.0, Delta=1.0)
     H = bond_term(m, 1, 2)
-    coefs = sort([ITensors.coefficient(t) for t in ITensors.terms(H)])
+    coefs = sort([real(ITensors.coefficient(t)) for t in ITensors.terms(H)])
     @test coefs == [1.0, 1.0, 1.0]
 end
 
@@ -30,7 +30,7 @@ end
     J, Delta = 1.0, 2.0
     m = S1XXZ1D(; J=J, Delta=Delta)
     H = bond_term(m, 1, 2)
-    coefs = sort([ITensors.coefficient(t) for t in ITensors.terms(H)])
+    coefs = sort([real(ITensors.coefficient(t)) for t in ITensors.terms(H)])
     @test coefs ≈ sort([J, J, J * Delta])
 end
 

--- a/test/base/test_s1_xxz_1d.jl
+++ b/test/base/test_s1_xxz_1d.jl
@@ -1,0 +1,79 @@
+using ITensorModels
+using ITensors
+using ITensors: SiteType
+using ITensorMPS
+using Random
+using Test
+
+@testset "S1XXZ1D: construction" begin
+    m = S1XXZ1D()
+    @test m isa AbstractLatticeModel
+    @test m.J == 1.0
+    @test m.Delta == 1.0
+    @test site_type(m) == SiteType("S=1")
+end
+
+@testset "S1XXZ1D: bond_term has 3 terms" begin
+    m = S1XXZ1D(; J=1.0, Delta=0.5)
+    H = bond_term(m, 1, 2)
+    @test length(collect(ITensors.terms(H))) == 3
+end
+
+@testset "S1XXZ1D: Delta=1 all coefficients equal J" begin
+    m = S1XXZ1D(; J=1.0, Delta=1.0)
+    H = bond_term(m, 1, 2)
+    coefs = sort([ITensors.coefficient(t) for t in ITensors.terms(H)])
+    @test coefs == [1.0, 1.0, 1.0]
+end
+
+@testset "S1XXZ1D: Delta scales Sz coupling" begin
+    J, Delta = 1.0, 2.0
+    m = S1XXZ1D(; J=J, Delta=Delta)
+    H = bond_term(m, 1, 2)
+    coefs = sort([ITensors.coefficient(t) for t in ITensors.terms(H)])
+    @test coefs ≈ sort([J, J, J * Delta])
+end
+
+@testset "S1XXZ1D: onsite and boundary empty" begin
+    m = S1XXZ1D()
+    @test length(collect(ITensors.terms(onsite_term(m, 1)))) == 0
+    @test length(collect(ITensors.terms(boundary_patch(m, 1)))) == 0
+end
+
+@testset "S1XXZ1D: onsite_observable_op" begin
+    m = S1XXZ1D()
+    @test onsite_observable_op(m, :sx) == "Sx"
+    @test onsite_observable_op(m, :sy) == "Sy"
+    @test onsite_observable_op(m, :sz) == "Sz"
+    @test_throws ErrorException onsite_observable_op(m, :bogus)
+end
+
+@testset "S1XXZ1D: Haldane DMRG smoke" begin
+    N = 6
+    m = S1XXZ1D(; J=1.0, Delta=1.0)
+    sites = siteinds("S=1", N)
+    H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
+    psi0 = random_mps(MersenneTwister(0xa1), sites; linkdims=12)
+    sweeps = Sweeps(15)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
+        200, 200, 200, 200, 200)
+    cutoff!(sweeps, 1e-12)
+    E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
+    @test isfinite(E)
+    @test E < 0
+end
+
+@testset "S1XXZ1D: large-Delta Neel DMRG smoke" begin
+    N = 6
+    m = S1XXZ1D(; J=1.0, Delta=5.0)
+    sites = siteinds("S=1", N)
+    H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
+    psi0 = random_mps(MersenneTwister(0xa2), sites; linkdims=12)
+    sweeps = Sweeps(15)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
+        200, 200, 200, 200, 200)
+    cutoff!(sweeps, 1e-12)
+    E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
+    @test isfinite(E)
+    @test E < 0
+end

--- a/test/base/test_s1_xxz_1d.jl
+++ b/test/base/test_s1_xxz_1d.jl
@@ -55,8 +55,7 @@ end
     H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
     psi0 = random_mps(MersenneTwister(0xa1), sites; linkdims=12)
     sweeps = Sweeps(15)
-    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
-        200, 200, 200, 200, 200)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200)
     cutoff!(sweeps, 1e-12)
     E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
     @test isfinite(E)
@@ -70,8 +69,7 @@ end
     H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
     psi0 = random_mps(MersenneTwister(0xa2), sites; linkdims=12)
     sweeps = Sweeps(15)
-    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
-        200, 200, 200, 200, 200)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200)
     cutoff!(sweeps, 1e-12)
     E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
     @test isfinite(E)


### PR DESCRIPTION
Adds S1XXZ1D — the S=1 Heisenberg chain with tunable XXZ anisotropy (Delta parameter). Spans Haldane phase at Delta=1 through Neel (large Delta) and XY (Delta=0) limits. Simple bond_term implementation on SiteType("S=1"). Tests cover construction, coefficients, phase-specific DMRG smoke.