### PR TITLE
feat(models): add SpinHalfXYZ1D (general anisotropic XYZ chain)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.7.14"
+version = "0.7.15"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/ITensorModels.jl
+++ b/src/ITensorModels.jl
@@ -24,6 +24,7 @@ export S1AnisotropicD1D
 export PXP1D
 export SSH1D
 export S1XXZ1D
+export SpinHalfXYZ1D
 export Cluster1D
 export TFIM, TFIML, XXZ1D, Heisenberg1D, S1Heisenberg1D, KitaevBond, LatticeModel
 export TFIM, TFIML, XXZ1D, Heisenberg1D, KitaevBond, TightBinding1D, LatticeModel
@@ -96,6 +97,7 @@ include("models/s1_anisotropic_d.jl")
 include("models/pxp_1d.jl")
 include("models/ssh_1d.jl")
 include("models/s1_xxz_1d.jl")
+include("models/spin_half_xyz_1d.jl")
 include("models/cluster_1d.jl")
 include("models/kitaev_bond.jl")
 include("models/xy_h_1d.jl")

--- a/src/models/spin_half_xyz_1d.jl
+++ b/src/models/spin_half_xyz_1d.jl
@@ -1,0 +1,40 @@
+using ITensors: SiteType, @SiteType_str
+
+"""
+    SpinHalfXYZ1D(; Jx=1.0, Jy=1.0, Jz=1.0, site=SiteType("S=1/2"))
+
+1D anisotropic XYZ Heisenberg chain on spin-1/2:
+
+    H = Jx sum_i Sx_i Sx_{i+1} + Jy sum_i Sy_i Sy_{i+1} + Jz sum_i Sz_i Sz_{i+1}
+
+The most general SU(2)-breaking nearest-neighbour two-body spin-1/2
+Hamiltonian. Special cases: Jx=Jy=Jz Heisenberg (XXX), Jx=Jy XXZ,
+Jx=Jy/Jz=0 XY. Exactly solvable by Bethe ansatz (XXZ) / Baxter (XYZ).
+"""
+Base.@kwdef struct SpinHalfXYZ1D <: AbstractLatticeModel
+    Jx::Float64 = 1.0
+    Jy::Float64 = 1.0
+    Jz::Float64 = 1.0
+    site::SiteType = SiteType("S=1/2")
+end
+
+site_type(m::SpinHalfXYZ1D) = m.site
+
+function bond_term(m::SpinHalfXYZ1D, i::Int, j::Int)
+    H = OpSum()
+    H += m.Jx, "Sx", i, "Sx", j
+    H += m.Jy, "Sy", i, "Sy", j
+    H += m.Jz, "Sz", i, "Sz", j
+    return H
+end
+
+boundary_patch(::SpinHalfXYZ1D, ::Int) = OpSum()
+bond_coupling_term(m::SpinHalfXYZ1D, i::Int, j::Int) = bond_term(m, i, j)
+onsite_term(::SpinHalfXYZ1D, ::Int) = OpSum()
+
+function onsite_observable_op(::SpinHalfXYZ1D, name::Symbol)
+    name === :sx && return "Sx"
+    name === :sy && return "Sy"
+    name === :sz && return "Sz"
+    return error("SpinHalfXYZ1D: unsupported onsite observable $name")
+end

--- a/test/base/test_spin_half_xyz_1d.jl
+++ b/test/base/test_spin_half_xyz_1d.jl
@@ -1,0 +1,78 @@
+using ITensorModels
+using ITensors
+using ITensors: SiteType
+using ITensorMPS
+using Random
+using Test
+
+@testset "SpinHalfXYZ1D: construction" begin
+    m = SpinHalfXYZ1D()
+    @test m isa AbstractLatticeModel
+    @test m.Jx == 1.0
+    @test m.Jy == 1.0
+    @test m.Jz == 1.0
+    @test site_type(m) == SiteType("S=1/2")
+end
+
+@testset "SpinHalfXYZ1D: bond_term has 3 terms" begin
+    m = SpinHalfXYZ1D(; Jx=0.5, Jy=0.7, Jz=1.2)
+    H = bond_term(m, 1, 2)
+    @test length(collect(ITensors.terms(H))) == 3
+end
+
+@testset "SpinHalfXYZ1D: coefficients match Jx Jy Jz" begin
+    Jx, Jy, Jz = 0.3, 0.7, 1.5
+    m = SpinHalfXYZ1D(; Jx=Jx, Jy=Jy, Jz=Jz)
+    H = bond_term(m, 1, 2)
+    coefs = sort([real(ITensors.coefficient(t)) for t in ITensors.terms(H)])
+    @test coefs ≈ sort([Jx, Jy, Jz])
+end
+
+@testset "SpinHalfXYZ1D: XXX limit equals Heisenberg" begin
+    m = SpinHalfXYZ1D(; Jx=1.0, Jy=1.0, Jz=1.0)
+    H = bond_term(m, 1, 2)
+    coefs = sort([real(ITensors.coefficient(t)) for t in ITensors.terms(H)])
+    @test coefs ≈ [1.0, 1.0, 1.0]
+end
+
+@testset "SpinHalfXYZ1D: onsite and boundary empty" begin
+    m = SpinHalfXYZ1D()
+    @test length(collect(ITensors.terms(onsite_term(m, 1)))) == 0
+    @test length(collect(ITensors.terms(boundary_patch(m, 1)))) == 0
+end
+
+@testset "SpinHalfXYZ1D: onsite_observable_op" begin
+    m = SpinHalfXYZ1D()
+    @test onsite_observable_op(m, :sx) == "Sx"
+    @test onsite_observable_op(m, :sy) == "Sy"
+    @test onsite_observable_op(m, :sz) == "Sz"
+    @test_throws ErrorException onsite_observable_op(m, :bogus)
+end
+
+@testset "SpinHalfXYZ1D: XXZ limit DMRG smoke" begin
+    N = 6
+    m = SpinHalfXYZ1D(; Jx=1.0, Jy=1.0, Jz=0.5)
+    sites = siteinds("S=1/2", N)
+    H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
+    psi0 = random_mps(MersenneTwister(0xb1), sites; linkdims=12)
+    sweeps = Sweeps(15)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200)
+    cutoff!(sweeps, 1e-12)
+    E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
+    @test isfinite(E)
+    @test E < 0
+end
+
+@testset "SpinHalfXYZ1D: XYZ DMRG smoke" begin
+    N = 6
+    m = SpinHalfXYZ1D(; Jx=0.5, Jy=0.7, Jz=1.0)
+    sites = siteinds("S=1/2", N)
+    H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
+    psi0 = random_mps(MersenneTwister(0xb2), sites; linkdims=12)
+    sweeps = Sweeps(15)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200)
+    cutoff!(sweeps, 1e-12)
+    E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
+    @test isfinite(E)
+    @test E < 0
+end


### PR DESCRIPTION
Adds SpinHalfXYZ1D — the most general SU(2)-breaking nearest-neighbour spin-1/2 chain with independent Jx, Jy, Jz couplings. Subsumes XXX, XXZ, XY, and Ising as special cases. Tests cover construction, coefficients, and DMRG smoke at XXZ and full XYZ parameter points.