### PR TITLE
feat(models): add S32Heisenberg1D (S=3/2 Heisenberg chain)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.7.13"
+version = "0.7.16"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/ITensorModels.jl
+++ b/src/ITensorModels.jl
@@ -23,6 +23,7 @@ export LongRangeXY1D
 export S1AnisotropicD1D
 export PXP1D
 export SSH1D
+export S32Heisenberg1D
 export Cluster1D
 export TFIM, TFIML, XXZ1D, Heisenberg1D, S1Heisenberg1D, KitaevBond, LatticeModel
 export TFIM, TFIML, XXZ1D, Heisenberg1D, KitaevBond, TightBinding1D, LatticeModel
@@ -94,6 +95,7 @@ include("models/long_range_xy_1d.jl")
 include("models/s1_anisotropic_d.jl")
 include("models/pxp_1d.jl")
 include("models/ssh_1d.jl")
+include("models/s32_heisenberg_1d.jl")
 include("models/cluster_1d.jl")
 include("models/kitaev_bond.jl")
 include("models/xy_h_1d.jl")

--- a/src/models/s32_heisenberg_1d.jl
+++ b/src/models/s32_heisenberg_1d.jl
@@ -1,0 +1,40 @@
+using ITensors: SiteType, @SiteType_str
+
+"""
+    S32Heisenberg1D(; J=1.0, site=SiteType("S=3/2"))
+
+S=3/2 isotropic antiferromagnetic Heisenberg chain:
+
+    H = J sum_i Si . S_{i+1}
+
+with SiteType("S=3/2"). By the Lieb-Mattis theorem and Haldane
+conjecture, half-integer spin chains are gapless (algebraic long-range
+order) in contrast to the gapped integer-spin Haldane phase.
+
+Useful benchmark for half-integer-spin DMRG / imaginary-time evolution.
+"""
+Base.@kwdef struct S32Heisenberg1D <: AbstractLatticeModel
+    J::Float64 = 1.0
+    site::SiteType = SiteType("S=3/2")
+end
+
+site_type(m::S32Heisenberg1D) = m.site
+
+function bond_term(m::S32Heisenberg1D, i::Int, j::Int)
+    H = OpSum()
+    H += m.J, "Sx", i, "Sx", j
+    H += m.J, "Sy", i, "Sy", j
+    H += m.J, "Sz", i, "Sz", j
+    return H
+end
+
+boundary_patch(::S32Heisenberg1D, ::Int) = OpSum()
+bond_coupling_term(m::S32Heisenberg1D, i::Int, j::Int) = bond_term(m, i, j)
+onsite_term(::S32Heisenberg1D, ::Int) = OpSum()
+
+function onsite_observable_op(::S32Heisenberg1D, name::Symbol)
+    name === :sx && return "Sx"
+    name === :sy && return "Sy"
+    name === :sz && return "Sz"
+    return error("S32Heisenberg1D: unsupported onsite observable $name")
+end

--- a/test/base/test_s32_heisenberg_1d.jl
+++ b/test/base/test_s32_heisenberg_1d.jl
@@ -1,0 +1,74 @@
+using ITensorModels
+using ITensors
+using ITensors: SiteType
+using ITensorMPS
+using Random
+using Test
+
+@testset "S32Heisenberg1D: construction" begin
+    m = S32Heisenberg1D()
+    @test m isa AbstractLatticeModel
+    @test m.J == 1.0
+    @test site_type(m) == SiteType("S=3/2")
+end
+
+@testset "S32Heisenberg1D: bond_term has 3 equal-J terms" begin
+    m = S32Heisenberg1D(; J=0.5)
+    H = bond_term(m, 1, 2)
+    terms = collect(ITensors.terms(H))
+    @test length(terms) == 3
+    coefs = [ITensors.coefficient(t) for t in terms]
+    @test all(c ≈ 0.5 for c in coefs)
+end
+
+@testset "S32Heisenberg1D: onsite and boundary empty" begin
+    m = S32Heisenberg1D()
+    @test length(collect(ITensors.terms(onsite_term(m, 1)))) == 0
+    @test length(collect(ITensors.terms(boundary_patch(m, 1)))) == 0
+end
+
+@testset "S32Heisenberg1D: onsite_observable_op" begin
+    m = S32Heisenberg1D()
+    @test onsite_observable_op(m, :sx) == "Sx"
+    @test onsite_observable_op(m, :sy) == "Sy"
+    @test onsite_observable_op(m, :sz) == "Sz"
+    @test_throws ErrorException onsite_observable_op(m, :bogus)
+end
+
+@testset "S32Heisenberg1D: build_opsum non-empty" begin
+    N = 4
+    m = S32Heisenberg1D(; J=1.0)
+    sites = siteinds("S=3/2", N)
+    H = build_opsum(m, sites; phys_sites=1:N, boundary=:full)
+    @test length(collect(ITensors.terms(H))) == 3 * (N - 1)
+end
+
+@testset "S32Heisenberg1D: AFM DMRG smoke" begin
+    N = 6
+    m = S32Heisenberg1D(; J=1.0)
+    sites = siteinds("S=3/2", N)
+    H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
+    psi0 = random_mps(MersenneTwister(0xc1), sites; linkdims=12)
+    sweeps = Sweeps(15)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
+        200, 200, 200, 200, 200)
+    cutoff!(sweeps, 1e-12)
+    E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
+    @test isfinite(E)
+    @test E < 0
+end
+
+@testset "S32Heisenberg1D: FM DMRG smoke" begin
+    N = 6
+    m = S32Heisenberg1D(; J=-1.0)
+    sites = siteinds("S=3/2", N)
+    H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
+    psi0 = random_mps(MersenneTwister(0xc2), sites; linkdims=12)
+    sweeps = Sweeps(15)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
+        200, 200, 200, 200, 200)
+    cutoff!(sweeps, 1e-12)
+    E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
+    @test isfinite(E)
+    @test E < 0
+end

--- a/test/base/test_s32_heisenberg_1d.jl
+++ b/test/base/test_s32_heisenberg_1d.jl
@@ -50,8 +50,7 @@ end
     H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
     psi0 = random_mps(MersenneTwister(0xc1), sites; linkdims=12)
     sweeps = Sweeps(15)
-    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
-        200, 200, 200, 200, 200)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200)
     cutoff!(sweeps, 1e-12)
     E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
     @test isfinite(E)
@@ -65,8 +64,7 @@ end
     H = MPO(build_opsum(m, sites; phys_sites=1:N, boundary=:full), sites)
     psi0 = random_mps(MersenneTwister(0xc2), sites; linkdims=12)
     sweeps = Sweeps(15)
-    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200,
-        200, 200, 200, 200, 200)
+    maxdim!(sweeps, 20, 50, 100, 150, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200)
     cutoff!(sweeps, 1e-12)
     E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
     @test isfinite(E)


### PR DESCRIPTION
Adds S32Heisenberg1D — the isotropic S=3/2 Heisenberg chain on SiteType("S=3/2"). Half-integer spin: gapless by Haldane conjecture / Lieb-Mattis, in contrast to the gapped S=1 chain. Useful benchmark for half-integer-spin DMRG and imaginary-time evolution.