### PR TITLE
test(s1-heisenberg): Fibonacci quasicrystal integration (fixed resubmit of #43)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.7.15"
+version = "0.7.16"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]
@@ -30,6 +30,7 @@ julia = "1.10"
 
 [extras]
 Lattice2D = "e8031020-b7ff-4f1d-bee4-f79aea4cf140"
+QuasiCrystal = "7178fac9-d2bf-4933-964d-a28131e4f2a4"
 LatticeCore = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
 QAtlas = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -37,4 +38,4 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Lattice2D", "LatticeCore", "QAtlas", "Random", "Statistics", "Test"]
+test = ["Lattice2D", "LatticeCore", "QAtlas", "QuasiCrystal", "Random", "Statistics", "Test"]

--- a/test/base/test_s1heisenberg_fibonacci.jl
+++ b/test/base/test_s1heisenberg_fibonacci.jl
@@ -1,0 +1,53 @@
+using ITensorModels
+using ITensors
+using ITensors: SiteType
+using ITensorMPS
+using LatticeCore
+using LatticeCore: num_sites, position, bonds
+using QuasiCrystal
+using QuasiCrystal: build_nearest_neighbor_bonds!
+using Random
+using Test
+
+@testset "S1Heisenberg1D on QuasiCrystal.fibonacci via LatticeModel" begin
+    lat = fibonacci(4)
+    build_nearest_neighbor_bonds!(lat; cutoff=2.0)
+    @test lat isa LatticeCore.AbstractLattice
+    sub = S1Heisenberg1D(; J=1.0)
+    base = LatticeModel(; lattice=lat, bond_models=Dict(:nearest => sub))
+    @test base isa LatticeModel
+    @test ITensorModels.site_type(base) == SiteType("S=1")
+
+    H = build_opsum(base, nothing)
+    nbonds = length(collect(bonds(lat)))
+    @test nbonds > 0
+    @test length(collect(ITensors.terms(H))) == 3 * nbonds
+end
+
+@testset "S1Heisenberg1D + spherical_ssd on fibonacci" begin
+    lat = fibonacci(4)
+    build_nearest_neighbor_bonds!(lat; cutoff=2.0)
+    sub = S1Heisenberg1D(; J=1.0)
+    base = LatticeModel(; lattice=lat, bond_models=Dict(:nearest => sub))
+    env = spherical_ssd(lat; radius=:circumscribed)
+    mod = modulated_lattice(base; envelope=env)
+    H = build_opsum(mod, nothing)
+    @test length(collect(ITensors.terms(H))) > 0
+end
+
+@testset "S1Heisenberg1D DMRG on Fibonacci smoke" begin
+    lat = fibonacci(3)
+    build_nearest_neighbor_bonds!(lat; cutoff=2.0)
+    sub = S1Heisenberg1D(; J=1.0)
+    base = LatticeModel(; lattice=lat, bond_models=Dict(:nearest => sub))
+    N = num_sites(lat)
+    sites = siteinds("S=1", N)
+    H = MPO(build_opsum(base, sites), sites)
+    psi0 = random_mps(MersenneTwister(0xfa), sites; linkdims=10)
+    sweeps = Sweeps(10)
+    maxdim!(sweeps, 20, 50, 100, 100, 100, 100, 100, 100, 100, 100)
+    cutoff!(sweeps, 1e-10)
+    E, _ = dmrg(H, psi0, sweeps; outputlevel=0)
+    @test isfinite(E)
+    @test E < 0.0
+end


### PR DESCRIPTION
Resubmits closed PR #43. Two real bugs fixed:

1. `site_type` was ambiguous across ITensorModels / LatticeCore / QuasiCrystal — now uses explicit `ITensorModels.site_type(base)`.
2. `fibonacci(4)` returns QuasicrystalData with empty bonds — added `build_nearest_neighbor_bonds!(lat; cutoff=2.0)` after construction.

Plus adds QuasiCrystal to test [extras] / [targets].

Validated locally: 8/8 tests pass.

Version: 0.7.15 -> 0.7.16 (patch).