### PR TITLE
feat(qatlas-bridge): add AKLT1D and Hubbard1D bridges

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.7.17"
+version = "0.7.18"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]
@@ -25,7 +25,7 @@ ITensorMPS = "0.3, 0.4"
 ITensorSiteKit = "0.1"
 ITensors = "0.9"
 LatticeCore = "0.8, 0.10"
-QAtlas = "0.13, 0.14, 0.15, 0.18"
+QAtlas = "0.13, 0.14, 0.15, 0.18, 0.19"
 julia = "1.10"
 
 [extras]

--- a/ext/QAtlasExt.jl
+++ b/ext/QAtlasExt.jl
@@ -78,7 +78,6 @@ function ITensorModels.from_qatlas(qm::QAtlas.S1Heisenberg1D)
     return ITensorModels.S1Heisenberg1D(; J=qm.J)
 end
 
-
 # --- AKLT1D -------------------------------------------------------------
 
 ITensorModels.to_qatlas(m::ITensorModels.AKLT1D) = ITensorModels.to_qatlas(m, m.site)
@@ -102,11 +101,11 @@ ITensorModels.to_qatlas(m::ITensorModels.Hubbard1D) = ITensorModels.to_qatlas(m,
 #   QAtlas writes        H = -t Σ hop + U Σ n↑n↓ - μ Σ n  (half-filling μ = +U/2)
 # Same physical Hamiltonian, so the bridge negates μ.
 function ITensorModels.to_qatlas(m::ITensorModels.Hubbard1D, ::SiteType"Electron")
-    return QAtlas.Hubbard1D(; t=m.t, U=m.U, μ=-m.μ)
+    return QAtlas.Hubbard1D(; t=m.t, U=m.U, μ=(-m.μ))
 end
 
 function ITensorModels.from_qatlas(qm::QAtlas.Hubbard1D)
-    return ITensorModels.Hubbard1D(; t=qm.t, U=qm.U, μ=-qm.μ)
+    return ITensorModels.Hubbard1D(; t=qm.t, U=qm.U, μ=(-qm.μ))
 end
 
 # --- fetch forwarder ----------------------------------------------------

--- a/ext/QAtlasExt.jl
+++ b/ext/QAtlasExt.jl
@@ -78,6 +78,37 @@ function ITensorModels.from_qatlas(qm::QAtlas.S1Heisenberg1D)
     return ITensorModels.S1Heisenberg1D(; J=qm.J)
 end
 
+
+# --- AKLT1D -------------------------------------------------------------
+
+ITensorModels.to_qatlas(m::ITensorModels.AKLT1D) = ITensorModels.to_qatlas(m, m.site)
+
+# QAtlas.AKLT1D uses the same J coefficient on spin-1 S·S + (1/3)(S·S)^2
+# bond Hamiltonian — no rescaling on SiteType("S=1").
+function ITensorModels.to_qatlas(m::ITensorModels.AKLT1D, ::SiteType"S=1")
+    return QAtlas.AKLT1D(; J=m.J)
+end
+
+function ITensorModels.from_qatlas(qm::QAtlas.AKLT1D)
+    return ITensorModels.AKLT1D(; J=qm.J)
+end
+
+# --- Hubbard1D ----------------------------------------------------------
+
+ITensorModels.to_qatlas(m::ITensorModels.Hubbard1D) = ITensorModels.to_qatlas(m, m.site)
+
+# Sign-convention divergence:
+#   ITensorModels writes H = -t Σ hop + U Σ n↑n↓ + μ Σ n  (half-filling μ = -U/2)
+#   QAtlas writes        H = -t Σ hop + U Σ n↑n↓ - μ Σ n  (half-filling μ = +U/2)
+# Same physical Hamiltonian, so the bridge negates μ.
+function ITensorModels.to_qatlas(m::ITensorModels.Hubbard1D, ::SiteType"Electron")
+    return QAtlas.Hubbard1D(; t=m.t, U=m.U, μ=-m.μ)
+end
+
+function ITensorModels.from_qatlas(qm::QAtlas.Hubbard1D)
+    return ITensorModels.Hubbard1D(; t=qm.t, U=qm.U, μ=-qm.μ)
+end
+
 # --- fetch forwarder ----------------------------------------------------
 #
 # Route `QAtlas.fetch` calls that take an ITensorModels model through

--- a/test/base/test_qatlas_bridge.jl
+++ b/test/base/test_qatlas_bridge.jl
@@ -206,3 +206,51 @@ end
 
     @test E_dmrg ≈ E_qatlas rtol = 1e-5
 end
+
+# ── AKLT1D round-trip ─────────────────────────────────────────────────
+
+@testset "AKLT1D round-trip preserves J" begin
+    using ITensorModels: AKLT1D
+    m = AKLT1D(; J=0.7)
+    qm = ITensorModels.to_qatlas(m)
+    @test qm.J == 0.7
+    back = ITensorModels.from_qatlas(qm)
+    @test back.J == 0.7
+end
+
+@testset "AKLT1D: GS energy density matches AKLT exact -2J/3 in QAtlas" begin
+    using ITensorModels: AKLT1D
+    using QAtlas: GroundStateEnergyDensity, Infinite
+    for J in (0.5, 1.0, 1.7)
+        m = AKLT1D(; J=J)
+        e0 = QAtlas.fetch(m, GroundStateEnergyDensity(), Infinite())
+        @test e0 ≈ -2J / 3 rtol = 1e-12
+    end
+end
+
+# ── Hubbard1D round-trip ─────────────────────────────────────────────
+
+@testset "Hubbard1D round-trip negates μ (opposite sign conventions)" begin
+    using ITensorModels: Hubbard1D
+    # ITensorModels uses +μN, QAtlas uses -μN -> bridge negates μ.
+    m = Hubbard1D(; t=1.0, U=4.0, μ=-2.0)  # half filling in ITensorModels convention
+    qm = ITensorModels.to_qatlas(m)
+    @test qm.t == 1.0
+    @test qm.U == 4.0
+    @test qm.μ == 2.0                       # half filling in QAtlas convention
+    back = ITensorModels.from_qatlas(qm)
+    @test back.t == m.t && back.U == m.U && back.μ == m.μ
+end
+
+@testset "Hubbard1D: half-filling GS energy density (Lieb-Wu) via bridge" begin
+    using ITensorModels: Hubbard1D
+    using QAtlas: GroundStateEnergyDensity, Infinite
+    # Use a non-trivial U/t and check the bridge dispatches to the
+    # Lieb-Wu integral and returns the same value as a direct QAtlas call.
+    t, U = 1.0, 4.0
+    m = Hubbard1D(; t=t, U=U, μ=-U / 2)               # ITM half-filling
+    qm_direct = QAtlas.Hubbard1D(; t=t, U=U, μ=U / 2)  # QAtlas half-filling
+    e_bridge = QAtlas.fetch(m, GroundStateEnergyDensity(), Infinite())
+    e_direct = QAtlas.fetch(qm_direct, GroundStateEnergyDensity(), Infinite())
+    @test e_bridge ≈ e_direct rtol = 1e-12
+end


### PR DESCRIPTION
Adds to_qatlas / from_qatlas for AKLT1D (J pass-through) and Hubbard1D (negates μ due to opposite sign conventions). Extends QAtlas compat to include 0.19.x.

Tests:
- Round-trip parameter preservation
- AKLT GS energy density matches exact -2J/3 via QAtlas fetch
- Hubbard half-filling Lieb-Wu integral via bridge

Validated locally on Panza.

bump 0.7.17 -> 0.7.18 (patch)