### PR TITLE
feat: high-spin (S=3/2, S=2) XXZ1D support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ LatticeCore = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
 QAtlas = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
 
 [sources.ITensorSiteKit]
-rev = "v0.1.0"
+rev = "v0.2.0"
 url = "https://github.com/sotashimozono/ITensorSiteKit.jl"
 
 [extensions]
@@ -23,7 +23,7 @@ QAtlasExt = "QAtlas"
 
 [compat]
 ITensorMPS = "0.3, 0.4"
-ITensorSiteKit = "0.1"
+ITensorSiteKit = "0.2"
 ITensors = "0.9"
 LatticeCore = "0.8, 0.10"
 QAtlas = "0.13, 0.14, 0.15, 0.18, 0.19, 0.20, 0.21, 0.22, 0.23, 0.24, 0.25"

--- a/src/models/xxz.jl
+++ b/src/models/xxz.jl
@@ -27,6 +27,10 @@ site_type(m::XXZ1D) = m.site
 _xxz_ops(::SiteType"S=1/2") = ("Sx", "Sy", "Sz", 1.0)
 _xxz_ops(::SiteType"Qubit") = ("X", "Y", "Z", 0.25)
 _xxz_ops(::SiteType"S=1") = ("Sx", "Sy", "Sz", 1.0)
+# High-spin sites (registered in ITensorSiteKit ≥ v0.2.0): same S operators,
+# unit scale — the spin-S Sx/Sy/Sz carry the standard operator norm.
+_xxz_ops(::SiteType"S=3/2") = ("Sx", "Sy", "Sz", 1.0)
+_xxz_ops(::SiteType"S=2") = ("Sx", "Sy", "Sz", 1.0)
 
 function bond_term(m::XXZ1D, i::Int, j::Int)
     xop, yop, zop, scale = _xxz_ops(m.site)

--- a/test/base/test_high_spin_xxz.jl
+++ b/test/base/test_high_spin_xxz.jl
@@ -1,0 +1,34 @@
+# High-spin XXZ1D support (S=3/2, S=2), enabled by the SiteType registration in
+# ITensorSiteKit ≥ v0.2.0 (Models #18). Checks that XXZ1D builds and DMRGs on a
+# high-spin site, validated against the INDEPENDENT closed-form Heisenberg-dimer
+# ground state E₀ = −J·S(S+1) (two spin-S coupled by S₁·S₂; total-spin-0 singlet).
+
+using ITensorModels, Test
+using ITensors: SiteType, dim
+using ITensorMPS: dmrg, random_mps, siteinds, MPO
+
+@testset "XXZ1D high-spin $st (Δ=1 Heisenberg dimer GS = -S(S+1))" for (st, S) in (
+    ("S=3/2", 1.5), ("S=2", 2.0)
+)
+    m = XXZ1D(; J=1.0, Δ=1.0, site=SiteType(st))
+    @test site_type(m) == SiteType(st)
+
+    # two-site chain; H = S₁·S₂ ⇒ singlet GS energy = -S(S+1)
+    sites = siteinds(st, 2)
+    @test all(dim.(sites) .== Int(2S + 1))
+    H = MPO(build_opsum(m, sites; phys_sites=1:2, boundary=:full), sites)
+    ψ0 = random_mps(sites; linkdims=4)
+    E, _ = dmrg(H, ψ0; nsweeps=10, maxdim=[10, 20, 40, 40], cutoff=1e-13, outputlevel=0)
+    @test E ≈ -S * (S + 1) atol = 1e-6
+end
+
+@testset "S1Heisenberg1D still routes through XXZ1D (regression)" begin
+    m = S1Heisenberg1D(; J=1.0)
+    @test site_type(m) == SiteType("S=1")
+    sites = siteinds("S=1", 2)
+    H = MPO(build_opsum(m, sites; phys_sites=1:2, boundary=:full), sites)
+    E, _ = dmrg(
+        H, random_mps(sites; linkdims=4); nsweeps=8, maxdim=40, cutoff=1e-12, outputlevel=0
+    )
+    @test E ≈ -2.0 atol = 1e-6   # S=1 dimer: -S(S+1) = -2
+end


### PR DESCRIPTION
Extends `_xxz_ops` to dispatch on the `S=3/2` / `S=2` SiteTypes newly registered in ITensorSiteKit v0.2.0, so `XXZ1D(site=SiteType("S=3/2"))` builds and DMRGs on high-spin sites (Models #18). Bumps the SiteKit source rev to v0.2.0 and compat to "0.2".

Test: XXZ1D at Δ=1 on S=3/2 and S=2 two-site chains reproduces the closed-form Heisenberg-dimer singlet energy E₀ = −S(S+1) via DMRG (independent expectation), plus an S=1 regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)