### PR TITLE
chore: track ITensorSiteKit v0.3.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.7.19"
+version = "0.7.20"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]
@@ -14,7 +14,7 @@ LatticeCore = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
 QAtlas = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
 
 [sources.ITensorSiteKit]
-rev = "v0.2.0"
+rev = "v0.3.0"
 url = "https://github.com/sotashimozono/ITensorSiteKit.jl"
 
 [extensions]
@@ -23,7 +23,7 @@ QAtlasExt = "QAtlas"
 
 [compat]
 ITensorMPS = "0.3, 0.4"
-ITensorSiteKit = "0.2"
+ITensorSiteKit = "0.2, 0.3"
 ITensors = "0.9"
 LatticeCore = "0.8, 0.10"
 QAtlas = "0.13, 0.14, 0.15, 0.18, 0.19, 0.20, 0.21, 0.22, 0.23, 0.24, 0.25"


### PR DESCRIPTION
Coordinate with the SiteKit release train. SiteKit is v0.3.0; widen Models compat to `0.2, 0.3` and pin [sources] rev to v0.3.0 so the ecosystem resolves on one SiteKit. High-spin XXZ tests green under v0.3.0. 0.7.19 → 0.7.20. 🤖 Generated with [Claude Code](https://claude.com/claude-code)