### PR TITLE
feat: TFIML → E8 QAtlas bridge (golden-ratio oracle for lattice Ising)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.7.20"
+version = "0.7.21"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/ext/QAtlasExt.jl
+++ b/ext/QAtlasExt.jl
@@ -78,6 +78,53 @@ function ITensorModels.from_qatlas(qm::QAtlas.S1Heisenberg1D)
     return ITensorModels.S1Heisenberg1D(; J=qm.J)
 end
 
+# --- TFIML → E8 (critical Ising + longitudinal field) -------------------
+#
+# The transverse-field Ising model at its CRITICAL transverse field,
+# perturbed by a small longitudinal field `h_z`, flows to the Zamolodchikov
+# E8 integrable field theory: 8 particles with masses fixed by E8, with
+# `m₂/m₁ = 2 cos(π/5) = φ` (golden ratio; observed in CoNb₂O₆). `QAtlas.E8`
+# is parameter-free and exposes the universal mass-RATIO spectrum via
+# `fetch(E8(), E8Spectrum(), Infinite())`. Those ratios are the `h_z → 0`
+# universal limit; a finite-`h_z` lattice model only approaches them.
+
+ITensorModels.to_qatlas(m::ITensorModels.TFIML) = ITensorModels.to_qatlas(m, m.site)
+
+# Qubit (Pauli): H = -J Σσᶻσᶻ - h_x Σσˣ - h_z Σσᶻ; Ising-critical at h_x = J.
+function ITensorModels.to_qatlas(m::ITensorModels.TFIML, ::SiteType"Qubit")
+    _warn_if_not_e8(m.h_x, m.J, m.h_z)
+    return QAtlas.E8()
+end
+
+# S=1/2 (Sᶻ,Sˣ = σ/2): Pauli couplings J/4, h_x/2 ⇒ critical at h_x = J/2.
+function ITensorModels.to_qatlas(m::ITensorModels.TFIML, ::SiteType"S=1/2")
+    _warn_if_not_e8(m.h_x, m.J / 2, m.h_z)
+    return QAtlas.E8()
+end
+
+# E8 universality holds only at the critical transverse field, and the mass
+# ratios are the h_z → 0 limit. Warn (do not hard-fail) so a caller can still
+# fetch the reference ratios while being told when they are off-regime.
+function _warn_if_not_e8(h_x, h_x_crit, h_z)
+    isapprox(h_x, h_x_crit; rtol=0.02) || @warn(
+        "TFIML→E8: the E8 spectrum requires the critical transverse field " *
+            "(h_x ≈ $(h_x_crit) for this site); got h_x=$(h_x). Returned E8 ratios may not apply.",
+        maxlog = 1,
+    )
+    (0 < h_z ≤ 0.2) || @warn(
+        "TFIML→E8: the E8 mass ratios are the h_z→0 universal limit; got h_z=$(h_z). " *
+            "A finite/large h_z only approximates them.",
+        maxlog = 1,
+    )
+    return nothing
+end
+
+# Inverse: a canonical critical TFIML with a small longitudinal perturbation.
+function ITensorModels.from_qatlas(::QAtlas.E8; J=1.0, h_z=0.01, site=SiteType("Qubit"))
+    h_x = site === SiteType("S=1/2") ? J / 2 : J
+    return ITensorModels.TFIML(; J=J, h_x=h_x, h_z=h_z, site=site)
+end
+
 # --- fetch forwarder ----------------------------------------------------
 #
 # Route `QAtlas.fetch` calls that take an ITensorModels model through

--- a/test/base/test_qatlas_bridge.jl
+++ b/test/base/test_qatlas_bridge.jl
@@ -1,7 +1,7 @@
-using ITensorModels: TFIM, XXZ1D, Heisenberg1D, site_type, to_qatlas, from_qatlas
+using ITensorModels: TFIM, TFIML, XXZ1D, Heisenberg1D, site_type, to_qatlas, from_qatlas
 using ITensors: SiteType, OpSum
 using QAtlas: QAtlas
-using QAtlas: Energy, MassGap, Infinite, OBC
+using QAtlas: Energy, MassGap, Infinite, OBC, E8, E8Spectrum
 
 # These tests are deliberately non-tautological: they validate the
 # QAtlas bridge against (a) analytic TFIM results and (b) agreement
@@ -205,4 +205,33 @@ end
     E_dmrg, _ = dmrg(H, psi0, sweeps; outputlevel=0)
 
     @test E_dmrg ≈ E_qatlas rtol = 1e-5
+end
+
+@testset "TFIML → E8 spectrum (golden ratio)" begin
+    φ = 2 * cos(π / 5)   # golden ratio, the E8 hallmark m₂/m₁
+
+    # Qubit (Pauli): critical at h_x = J
+    m = TFIML(; J=1.0, h_x=1.0, h_z=0.05, site=SiteType("Qubit"))
+    @test to_qatlas(m) isa E8
+    ratios = QAtlas.fetch(m, E8Spectrum(), Infinite())
+    @test length(ratios) == 8
+    @test ratios[1] ≈ 1.0
+    @test ratios[2] ≈ φ rtol = 1e-10                 # golden ratio
+
+    # S=1/2 (Sᶻ,Sˣ = σ/2): critical at h_x = J/2 — same physics, different units
+    m_s = TFIML(; J=1.0, h_x=0.5, h_z=0.05)          # S=1/2 default site
+    @test to_qatlas(m_s) isa E8
+    @test QAtlas.fetch(m_s, E8Spectrum(), Infinite())[2] ≈ φ rtol = 1e-10
+
+    # forwarder parity with a direct E8 fetch
+    @test QAtlas.fetch(m, E8Spectrum(), Infinite()) ==
+        QAtlas.fetch(E8(), E8Spectrum(), Infinite())
+
+    # inverse: canonical critical TFIML
+    back = from_qatlas(E8())
+    @test back isa TFIML && back.h_x ≈ back.J && back.site === SiteType("Qubit")
+
+    # off-critical h_x warns (E8 only at criticality) but still returns ratios
+    m_off = TFIML(; J=1.0, h_x=0.4, h_z=0.05, site=SiteType("Qubit"))
+    @test (@test_logs (:warn,) match_mode = :any to_qatlas(m_off)) isa E8
 end


### PR DESCRIPTION
## Summary

Connects the lattice **TFIML** (transverse-field Ising + longitudinal field) to QAtlas's **E8** universality oracle.

Critical TFIM (`h_x` = critical) + small longitudinal field `h_z` realises the Zamolodchikov **E8** integrable field theory: 8 mesons with masses fixed by E8, `m₂/m₁ = 2cos(π/5) = φ` (golden ratio; observed in CoNb₂O₆). QAtlas already exposes the universal ratios via `fetch(E8(), E8Spectrum(), Infinite())`, but nothing bridged the lattice model to it — so a lattice E8 computation had no `fetch`-able independent oracle.

## Change

- `to_qatlas(::TFIML) -> QAtlas.E8()`, site-aware: **Qubit** critical at `h_x = J`; **S=1/2** at `h_x = J/2` (the `Sᶻ,Sˣ = σ/2` convention). Via the existing forwarder, `QAtlas.fetch(TFIML(...), E8Spectrum(), Infinite())` now returns the E8 tower.
- `_warn_if_not_e8` flags off-critical `h_x` or non-small `h_z` (the ratios are the `h_z → 0` universal limit) **without hard-failing** — you can still fetch the reference ratios.
- Inverse `from_qatlas(::E8)` returns a canonical critical TFIML.

## Why

Matches the dual-oracle / test-against-independent-expectations philosophy: lattice E8 spectroscopy (the complex-time nonlinear-response program's target system) can now validate its masses against the exact golden-ratio spectrum with one `fetch`.

## Test

`fetch(TFIML, E8Spectrum, Infinite)` returns the 8-mass tower `[1.0, 1.618, 1.989, …]` with `m₂/m₁ = φ` in **both** site conventions; forwarder parity with a direct `E8()` fetch; round-trip; off-critical `@test_logs` warning. Passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)