### PR TITLE
chore: retarget repo links after org move

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: 💬 Discussions
-    url: https://github.com/sotashimozono/ITensorModels.jl/discussions
+    url: https://github.com/lab-sotashimozono/ITensorModels.jl/discussions
     about: Use `Discussions` for questions and general discussions

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ QAtlas = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
 
 [sources.ITensorSiteKit]
 rev = "v0.3.0"
-url = "https://github.com/sotashimozono/ITensorSiteKit.jl"
+url = "https://github.com/lab-sotashimozono/ITensorSiteKit.jl"
 
 [extensions]
 LatticeCoreExt = "LatticeCore"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <a id="badge-top"></a>
 [![codecov](https://codecov.io/gh/sotashimozono/template.jl/graph/badge.svg?token=Q3oEEiz9A2)](https://codecov.io/gh/sotashimozono/template.jl)
-[![Build Status](https://github.com/sotashimozono/ITensorModels.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/sotashimozono/ITensorModels.jl/actions/workflows/CI.yml?query=branch%3Amain)
+[![Build Status](https://github.com/lab-sotashimozono/ITensorModels.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/lab-sotashimozono/ITensorModels.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 this repository is made for template folder for developing julia project.  

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -31,7 +31,7 @@ makedocs(;
 )
 
 deploydocs(;
-    repo="github.com/sotashimozono/ITensorModels.jl.git",
+    repo="github.com/lab-sotashimozono/ITensorModels.jl.git",
     devbranch="main",
     push_preview=true,
 )


### PR DESCRIPTION
Automated owner rewrite of repo links after the move to the lab-sotashimozono org: lab repos → lab-sotashimozono, QAtlas-family (QAtlas/AbstractQAtlas/DataVault/ParamIO/Pinax) → QAtlasHub. Covers badges, docs, deploydocs, submodule/[sources] URLs (submodules kept for version pinning). Untouched: LICENSE, avatar, template.jl, ParallelManager (not yet moved).