### PR TITLE
ci: reusable release-drafter + TagBot policy

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,31 +1,20 @@
-name: TagBot
+name: TagBot   # PUBLIC repos only — private repos are not in General, so JuliaTagBot never comments
 on:
   issue_comment:
-    types:
-      - created
+    types: [created]
   workflow_dispatch:
     inputs:
       lookback:
         default: "3"
-permissions:
-  actions: read
-  checks: read
-  contents: write
-  deployments: read
-  issues: read
-  discussions: read
-  packages: read
-  pages: read
-  pull-requests: read
-  repository-projects: read
-  security-events: read
-  statuses: read
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: JuliaRegistries/TagBot@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
+    permissions:
+      contents: write
+      actions: read
+      checks: read
+      statuses: read
+      issues: read
+      pull-requests: read
+    uses: lab-sotashimozono/.github/.github/workflows/tagbot.yml@main
+    secrets: inherit

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,21 +1,16 @@
-name: Release Drafter
-
+name: Release Drafter   # AutoRegister keys off this exact name — do not rename
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   pull_request:
-    types: [opened, reopened, synchronize, labeled]
-
+    types: [opened, reopened, synchronize, edited]   # autolabeler acts on PRs
+permissions:
+  contents: read
 jobs:
   update_release_draft:
     permissions:
       contents: write
       pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: release-drafter/release-drafter@v7
-        with:
-          commitish: main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: lab-sotashimozono/.github/.github/workflows/release-drafter.yml@main
+    with:
+      runner: '"ubuntu-latest"'


### PR DESCRIPTION
Release Drafter now calls the org reusable (workflow *name* kept as 'Release Drafter' — AutoRegister triggers on it). TagBot → reusable (public: registers in General)