### PR TITLE
ci: fix CompatHelper (org reusable)

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,25 +1,14 @@
 name: CompatHelper
 on:
   schedule:
-    - cron: '0 0 * * *'  # daily midnight UTC
+    - cron: '0 0 * * *'
   workflow_dispatch:
-
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
-  CompatHelper:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: julia-actions/cache@v3
-      - name: Install CompatHelper
-        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
-      - name: Run CompatHelper
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: julia -e 'using CompatHelper; CompatHelper.main()'
+  compat:
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: lab-sotashimozono/.github/.github/workflows/compathelper.yml@main
+    with:
+      runner: '"ubuntu-latest"'
+    secrets: inherit   # BOT_PAT is an org secret (visibility=all)


### PR DESCRIPTION
The per-repo CompatHelper died with **exit 127 (julia: command not found)** — the rosina runner's PATH does not carry ~/.juliaup/bin into a job. Switch to the org reusable, which always runs setup-julia and authors the PR with the org BOT_PAT (so the compat PR triggers CI).