### PR TITLE
deps: track main for every internal [sources]

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ LatticeCore = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
 QAtlas = "2bd488d2-d3e6-46ee-afb3-5515643db0c7"
 
 [sources.ITensorSiteKit]
-rev = "v0.3.0"
+rev = "main"
 url = "https://github.com/lab-sotashimozono/ITensorSiteKit.jl"
 
 [extensions]
@@ -23,7 +23,7 @@ QAtlasExt = "QAtlas"
 
 [compat]
 ITensorMPS = "0.3, 0.4"
-ITensorSiteKit = "0.2, 0.3"
+ITensorSiteKit = "0.2, 0.3, 0.4"
 ITensors = "0.9"
 LatticeCore = "0.8, 0.10, 0.12"
 QAtlas = "0.13, 0.14, 0.15, 0.18, 0.19, 0.20, 0.21, 0.22, 0.23, 0.24, 0.25"


### PR DESCRIPTION
Fleet policy: every internal (lab-sotashimozono/*) `[sources]` dep tracks `rev = "main"`; compat widened to admit main's current version. External `ITensor/*` pins are left alone.

Tag pins are what rotted the fleet — a repo stuck on an old tag conflicts with a sibling that follows main and drags in the newer requirement. CompatHelper is blind to git `[sources]`, so nothing ever refreshed them.