### PR TITLE
ci: shard the test suite (N=8, hosted runners, timing-driven LPT)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,30 +5,215 @@ on:
       - main
     tags: '*'
   pull_request:
+  workflow_dispatch:        # manual re-trigger
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write           # record-timings force-pushes the `ci-timings` orphan branch
+
 jobs:
-  test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - '1'
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
+  # ───────────────────────────────────────────────────────────────────────────
+  # Shard planner. WHAT to run = the canonical universe (test/ci/universe.jl,
+  # single source of truth + completeness guard). This job only decides HOW to
+  # split it: Longest-Processing-Time bin-packing against the `ci-timings` orphan
+  # branch when it exists, else deterministic round-robin.
+  #
+  # N lives HERE and nowhere else. N is a REQUEST: the planner emits
+  # min(N, #test-files) shards, so a small suite can never produce a shard that
+  # runs zero tests.
+  #
+  # ITensorModels is a PUBLIC repo, so every job runs on GitHub-hosted ubuntu-latest
+  # (free minutes). The rosina self-hosted pool is off-limits to public repos — a fork
+  # PR would otherwise execute arbitrary code on our box.
+  # ───────────────────────────────────────────────────────────────────────────
+  plan:
+    name: Plan shards
+    runs-on: ubuntu-latest
+    outputs:
+      plan: ${{ steps.gen.outputs.plan }}
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
+          version: '1'
+          arch: x64
+      - name: Fetch timing history (best-effort)
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin ci-timings >/dev/null 2>&1; then
+            git fetch --depth=1 origin ci-timings
+            git show FETCH_HEAD:timings.tsv > timings.tsv 2>/dev/null \
+              && echo "Loaded $(wc -l < timings.tsv) timing rows" \
+              || { echo "ci-timings has no timings.tsv — round-robin"; : > timings.tsv; }
+          else
+            echo "no ci-timings branch yet — round-robin fallback"
+            : > timings.tsv
+          fi
+      - id: gen
+        run: |
+          set -euo pipefail
+          N=8
+          # The planner is PURE STDLIB (universe.jl never does `using ITensorModels`), so
+          # it must not touch the project env — no precompile of the ITensors stack.
+          plan=$(julia --startup-file=no test/ci/plan_shards.jl "$N" timings.tsv)
+          count=$(printf '%s' "$plan" | jq 'length')
+          if [ "$count" -lt 1 ]; then
+            echo "::error::plan_shards produced an empty plan (count=$count)"
+            exit 1
+          fi
+          echo "plan=$plan" >> "$GITHUB_OUTPUT"
+          echo "Planned $count shards."
+
+  test:
+    name: shard ${{ matrix.sid }}
+    runs-on: ubuntu-latest
+    needs: plan
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.plan.outputs.plan) }}
+    env:
+      ITENSORMODELS_TEST_FILES: ${{ matrix.files }}
+      ITENSORMODELS_SHARD_ID: ${{ matrix.sid }}
+      # Only a push to main persists timings — a PR must not rewrite the very history it
+      # was planned against.
+      ITENSORMODELS_EMIT: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && '1' || '0' }}
+      # julia-runtest SANDBOXES Pkg.test into a temp copy, so @__DIR__ points somewhere
+      # upload-artifact will never look. Pin the emit dir into the workspace.
+      ITENSORMODELS_CIOUT_DIR: ${{ github.workspace }}/test/.ci-out
+    steps:
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: '1'
+          arch: x64
+      # A hosted runner has NO persistent depot: without a cache every shard would
+      # recompile the entire ITensors stack from scratch.
       - uses: julia-actions/cache@v3
+        with:
+          cache-name: shard-${{ matrix.sid }}
+          # The default include-matrix:true serializes the ENTIRE matrix context
+          # (including the multi-KB `files` list) into the cache key, blowing the
+          # 512-char key limit — every restore AND save then fails with
+          # "Key Validation Error" and each shard recompiles all deps on every run.
+          # matrix.sid is already in cache-name.
+          include-matrix: 'false'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
+      - uses: actions/upload-artifact@v7
+        with:
+          name: coverage-${{ matrix.sid }}
+          path: lcov.info
+          retention-days: 1
+          if-no-files-found: error
+          overwrite: true
+      - name: Upload shard timing (push:main only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v7
+        with:
+          name: timing-${{ matrix.sid }}
+          path: test/.ci-out/timings-*.tsv
+          retention-days: 1
+          if-no-files-found: warn
+          overwrite: true
+          include-hidden-files: true
+
+  record-timings:
+    name: Record timing history
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.test.result == 'success'
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          path: timing-parts
+          pattern: timing-*
+      - name: Merge into the ci-timings orphan branch (latest value wins)
+        run: |
+          set -euo pipefail
+          mkdir -p merged
+          if git ls-remote --exit-code --heads origin ci-timings >/dev/null 2>&1; then
+            git fetch --depth=1 origin ci-timings
+            git show FETCH_HEAD:timings.tsv > merged/timings.tsv 2>/dev/null || : > merged/timings.tsv
+          else
+            : > merged/timings.tsv
+          fi
+          find timing-parts -name 'timings-*.tsv' -exec cat {} + >> merged/timings.tsv || true
+          awk -F'\t' 'NF==2{t[$1]=$2} END{for (k in t) print k"\t"t[k]}' \
+            merged/timings.tsv | sort > merged/final.tsv
+          rows=$(wc -l < merged/final.tsv)
+          if [ "$rows" -lt 1 ]; then
+            echo "::error::push:main produced 0 timing rows — the emit path is broken (sandbox / ITENSORMODELS_CIOUT_DIR). Failing loudly instead of degrading to round-robin forever, silently."
+            exit 1
+          fi
+          echo "Merged timing rows: $rows"
+          tmp=$(mktemp -d)
+          cp merged/final.tsv "$tmp/timings.tsv"
+          cd "$tmp"
+          git init -q
+          git config user.email "ci@itensormodels"
+          git config user.name "itensormodels-ci"
+          git checkout -q -b ci-timings
+          git add timings.tsv
+          git commit -q -m "ci: refresh test timings ($rows rows) [skip ci]"
+          git push -q --force \
+            "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" ci-timings
+
+  coverage:
+    name: Coverage (aggregated)
+    runs-on: ubuntu-latest
+    needs: test
+    if: always() && needs.test.result != 'cancelled'
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          path: coverage-parts
+          pattern: coverage-*
+      - name: Merge the per-shard lcov reports
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(find coverage-parts -name 'lcov.info' | sort)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::No coverage artifacts found"
+            exit 1
+          fi
+          echo "Merging ${#files[@]} lcov reports"
+          if command -v lcov >/dev/null 2>&1; then
+            args=(); for f in "${files[@]}"; do args+=(-a "$f"); done
+            lcov "${args[@]}" -o lcov.info
+          else
+            # A concatenation is still a valid lcov report — codecov merges duplicate
+            # records itself.
+            cat "${files[@]}" > lcov.info
+          fi
       - uses: codecov/codecov-action@v7
         with:
           file: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
+  all-tests:
+    name: All tests passed
+    runs-on: ubuntu-latest
+    needs: [plan, test]
+    if: always()
+    steps:
+      - name: Check the plan and every shard passed
+        run: |
+          if [ "${{ needs.plan.result }}" != "success" ]; then
+            echo "Shard planning failed: ${{ needs.plan.result }}"; exit 1
+          fi
+          plan='${{ needs.plan.outputs.plan }}'
+          if [ -z "$plan" ] || [ "$plan" = "[]" ]; then
+            echo "Plan produced no shards — the test matrix would be empty"; exit 1
+          fi
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "One or more test shards failed: ${{ needs.test.result }}"; exit 1
+          fi
+          echo "All shards green."

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorModels"
 uuid = "ef2189cb-6e0f-43f0-8f34-d6f851ec88d5"
-version = "0.7.21"
+version = "0.7.22"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/test/ci/plan_shards.jl
+++ b/test/ci/plan_shards.jl
@@ -1,0 +1,119 @@
+# test/ci/plan_shards.jl — emit a balanced GitHub-matrix shard plan.
+#
+#   julia test/ci/plan_shards.jl <N> [timings.tsv]
+#
+# Prints (stdout, last line) a JSON array for `matrix: include:` —
+#   [{"sid":"s1","files":"base/test_a.jl,base/test_b.jl","aqua":"1"}, …]
+#
+# WHAT to run is the canonical universe (universe.jl — the single source of truth
+# + completeness guard). Timings only decide HOW to split:
+#   * timings.tsv present → Longest-Processing-Time bin-packing, so every shard
+#                           finishes at roughly the same wall-clock.
+#   * absent / unreadable → deterministic round-robin (identical to the
+#                           ITENSORMODELS_TEST_SHARD k/N fallback). Never a leak,
+#                           just not yet time-optimal.
+#
+# A new / unknown file gets a PESSIMISTIC estimate (P90 of the known times) so a
+# surprise-heavy new test is isolated rather than piled onto an already-heavy shard.
+#
+# The "aqua" field is emitted for parity with the sibling repos' planner (it marks the
+# lightest shard, the one that would carry a whole-package one-shot check). ITensorModels
+# has no Aqua suite today, so runtests.jl simply ignores it — wiring Aqua in later needs
+# no planner change.
+#
+# Ported from QAtlas.jl's test/ci/plan_shards.jl.
+
+include(joinpath(@__DIR__, "universe.jl"))   # ALL_TEST_FILES, test_file_key
+
+const N = let a = get(ARGS, 1, "")
+    n = tryparse(Int, a)
+    (n !== nothing && n >= 1) ||
+        error("plan_shards.jl: arg 1 must be N>=1; got $(repr(a))")
+    n
+end
+const TIMINGS_PATH = get(ARGS, 2, "")
+
+const KEYS = [test_file_key(d, f) for (d, f) in ALL_TEST_FILES]
+
+# Load "key\tseconds"; silently ignore missing/garbage rows — the timing plane is
+# advisory and must DEGRADE, never abort planning.
+function load_timings(path)
+    t = Dict{String,Float64}()
+    (isempty(path) || !isfile(path)) && return t
+    for ln in eachline(path)
+        parts = split(strip(ln), '\t')
+        length(parts) == 2 || continue
+        v = tryparse(Float64, parts[2])
+        v === nothing && continue
+        t[String(parts[1])] = v
+    end
+    return t
+end
+const TIMES = load_timings(TIMINGS_PATH)
+
+const DEFAULT_T = if isempty(TIMES)
+    1.0
+else
+    s = sort(collect(values(TIMES)))
+    s[clamp(ceil(Int, 0.9 * length(s)), 1, length(s))]   # P90 of the known times
+end
+
+est(k) = get(TIMES, k, DEFAULT_T)
+
+bins = [String[] for _ in 1:N]
+loads = zeros(Float64, N)
+
+if isempty(TIMES)
+    for (i, k) in enumerate(KEYS)
+        b = ((i - 1) % N) + 1
+        push!(bins[b], k)
+        loads[b] += est(k)
+    end
+    mode = "round-robin (no timing history)"
+else
+    for k in sort(KEYS; by=est, rev=true)      # longest first
+        b = argmin(loads)                       # → least-loaded bin
+        push!(bins[b], k)
+        loads[b] += est(k)
+    end
+    mode = "LPT bin-packing"
+end
+
+# Drop empty bins. N is a REQUEST, not a promise: a suite with fewer files than N
+# would otherwise emit shards that run zero tests (and, with the SHARD k/N fallback,
+# silently pass). The emitted plan always has min(N, #files) shards.
+const KEEP = [b for b in 1:N if !isempty(bins[b])]
+bins = bins[KEEP]
+loads = loads[KEEP]
+const NSHARDS = length(bins)
+
+# Aqua is a one-shot whole-package check: give it to the shard that finishes
+# EARLIEST, so it never lands on the critical path.
+const AQUA_BIN = argmin(loads)
+
+io = IOBuffer()                                 # ASCII paths ⇒ no escaping needed
+print(io, "[")
+for b in 1:NSHARDS
+    b == 1 || print(io, ",")
+    sid = "s" * string(b)
+    print(io, "{\"sid\":\"", sid, "\",\"files\":\"", join(bins[b], ","), "\",")
+    print(io, "\"aqua\":\"", b == AQUA_BIN ? "1" : "0", "\"}")
+end
+print(io, "]")
+plan_json = String(take!(io))
+
+# Human-readable summary → stderr (must NOT pollute the JSON on stdout).
+println(
+    stderr,
+    "plan_shards: N=$N → $NSHARDS shards  mode=$mode  files=$(length(KEYS))  " *
+    "default_t=$(round(DEFAULT_T; digits=3))s  aqua→s$(AQUA_BIN)",
+)
+for b in 1:NSHARDS
+    println(
+        stderr,
+        "  s$(b): $(length(bins[b])) files  est=$(round(loads[b]; digits=1))s" *
+        (b == AQUA_BIN ? "  +aqua" : ""),
+    )
+end
+
+println(plan_json)

--- a/test/ci/universe.jl
+++ b/test/ci/universe.jl
@@ -1,0 +1,61 @@
+# test/ci/universe.jl — canonical test-file universe (single source of truth).
+#
+# Included by BOTH test/runtests.jl and test/ci/plan_shards.jl. Pure stdlib, NO
+# `using ITensorModels`, so the shard planner stays cheap (it must not precompile the
+# ITensors stack just to decide how to split the suite).
+#
+# This file alone decides WHAT the suite is. The timing history only decides HOW to
+# split it — it can never add or drop a file.
+#
+# Ported from QAtlas.jl's test/ci/universe.jl.
+
+const TEST_ROOT = dirname(@__DIR__)   # test/ci/ → test/
+
+const ALL_DIRS = ["base/"]
+
+_is_test_file(f) = startswith(f, "test_") && endswith(f, ".jl")
+
+# ── Completeness guard ───────────────────────────────────────────────
+# Every on-disk directory holding a `test_*.jl` MUST be enumerated in ALL_DIRS, and
+# every ALL_DIRS entry must exist and be non-empty. Runs wherever this file is
+# included (every shard + the planner) and fails loudly — so a new test directory
+# can never be added without being wired in, silently running zero tests.
+let
+    enumerated = Set(ALL_DIRS)
+    discovered = Set{String}()
+    for (d, _, files) in walkdir(TEST_ROOT)
+        any(_is_test_file, files) || continue
+        rel = replace(relpath(d, TEST_ROOT), '\\' => '/')
+        rel == "." && continue          # test/ root holds runtests.jl only
+        startswith(rel, "ci") && continue
+        push!(discovered, rel * "/")
+    end
+    leaked = sort(collect(setdiff(discovered, enumerated)))
+    isempty(leaked) || error(
+        "universe.jl completeness guard: these on-disk test directories hold " *
+        "test_*.jl files but are NOT in ALL_DIRS and would never run — add them " *
+        "to ALL_DIRS: $(leaked)",
+    )
+    for d in ALL_DIRS
+        p = joinpath(TEST_ROOT, d)
+        (isdir(p) && any(_is_test_file, readdir(p))) || error(
+            "universe.jl completeness guard: ALL_DIRS entry $(repr(d)) is missing " *
+            "on disk or contains no test_*.jl files.",
+        )
+    end
+end
+
+# ── Canonical, deterministic global test-file universe ───────────────
+# ALL_DIRS order × lexically-sorted files. Every selection mode picks a SUBSET of
+# this list, so the union of all shards is exactly this set.
+const ALL_TEST_FILES = let acc = Tuple{String,String}[]
+    for d in ALL_DIRS
+        for f in sort(filter(_is_test_file, readdir(joinpath(TEST_ROOT, d))))
+            push!(acc, (d, f))
+        end
+    end
+    acc
+end
+
+# Stable "d/f" key used by the timing history and ITENSORMODELS_TEST_FILES.
+test_file_key(d, f) = d * f

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,75 @@
 ENV["GKSwstype"] = "100"
 
 using ITensorModels, Test
-const dirs = ["base"]
+
+# Canonical universe + completeness guard — the single source of truth, shared
+# VERBATIM with the shard planner (test/ci/plan_shards.jl).
+include(joinpath(@__DIR__, "ci", "universe.jl"))
+
+# ── Test selection: FILES > SHARD > ALL ──────────────────────────────
+#
+#   ITENSORMODELS_TEST_FILES="base/test_a.jl,base/test_b.jl"
+#       explicit list emitted by the LPT shard planner. MUST be a subset of the
+#       canonical universe (the planner cannot smuggle in an unglobbed file).
+#   ITENSORMODELS_TEST_SHARD="k/N"
+#       round-robin shard — timing-agnostic; the planner's fallback and a manual knob.
+#   neither
+#       run everything.
+#
+# NOTHING is set by default, so a bare `Pkg.test()` — locally, or from any tool that has
+# not adopted the sharded workflow — behaves EXACTLY as before: all files, same order.
+# The sharding is additive; it never changes the default meaning of the suite.
+#
+# (The planner also emits an "aqua" flag per shard, for parity with the sibling repos.
+# ITensorModels has no Aqua suite today, so nothing here consumes it.)
+const _files_spec = get(ENV, "ITENSORMODELS_TEST_FILES", "")
+const _shard_spec = get(ENV, "ITENSORMODELS_TEST_SHARD", "")
+
+const _selected, _mode_desc = if !isempty(_files_spec)
+    want = [strip(x) for x in split(_files_spec, ",") if !isempty(strip(x))]
+    idx = Dict(test_file_key(d, f) => (d, f) for (d, f) in ALL_TEST_FILES)
+    sel = Tuple{String,String}[]
+    unknown = String[]
+    for w in want
+        haskey(idx, w) ? push!(sel, idx[w]) : push!(unknown, String(w))
+    end
+    isempty(unknown) || error(
+        "ITENSORMODELS_TEST_FILES lists files outside the canonical universe " *
+        "(the planner must only emit globbed files): $(unknown)",
+    )
+    (sel, "FILES (n=$(length(sel)))")
+elseif !isempty(_shard_spec)
+    parts = split(_shard_spec, "/")
+    length(parts) == 2 ||
+        error("ITENSORMODELS_TEST_SHARD must be \"k/N\"; got $(repr(_shard_spec))")
+    k = tryparse(Int, strip(parts[1]))
+    n = tryparse(Int, strip(parts[2]))
+    (k !== nothing && n !== nothing) || error(
+        "ITENSORMODELS_TEST_SHARD must be integer \"k/N\"; got $(repr(_shard_spec))"
+    )
+    (1 <= k <= n) || error("ITENSORMODELS_TEST_SHARD k/N needs 1 ≤ k ≤ N; got $k/$n")
+    n <= length(ALL_TEST_FILES) || error(
+        "ITENSORMODELS_TEST_SHARD N=$n exceeds the $(length(ALL_TEST_FILES))-file suite; " *
+        "shards $(length(ALL_TEST_FILES) + 1)..$n would run zero tests — lower N.",
+    )
+    sel = [tf for (i, tf) in enumerate(ALL_TEST_FILES) if ((i - 1) % n) + 1 == k]
+    (sel, "SHARD $k/$n")
+else
+    (ALL_TEST_FILES, "ALL")
+end
+
+println(
+    "Test selection: $(_mode_desc) → $(length(_selected))/$(length(ALL_TEST_FILES)) files"
+)
+
+# Per-file wall-clock, emitted so the NEXT run's planner can LPT bin-pack instead of
+# falling back to round-robin. `julia-actions/julia-runtest` SANDBOXES Pkg.test into a
+# temp copy, so `@__DIR__` points somewhere `upload-artifact` will never look — CI pins
+# the output dir into the workspace via ITENSORMODELS_CIOUT_DIR.
+const _emit = get(ENV, "ITENSORMODELS_EMIT", "0") == "1"
+const _ciout = get(ENV, "ITENSORMODELS_CIOUT_DIR", joinpath(@__DIR__, ".ci-out"))
+const _sid = get(ENV, "ITENSORMODELS_SHARD_ID", "local")
+_emit && mkpath(_ciout)
 
 const FIG_BASE = joinpath(pkgdir(ITensorModels), "docs", "src", "assets")
 const PATHS = Dict()
@@ -10,25 +78,27 @@ mkpath.(values(PATHS))
 @testset "tests" begin
     test_args = copy(ARGS)
     println("Passed arguments ARGS = $(test_args) to tests.")
-    @time for dir in dirs
-        dirpath = joinpath(@__DIR__, dir)
-        println("\nTest $(dirpath)")
-        files = sort(
-            filter(f -> startswith(f, "test_") && endswith(f, ".jl"), readdir(dirpath))
-        )
-        if isempty(files)
-            println("  No test files found in $(dirpath).")
-            @test false
-        else
-            for f in files
-                @testset "$f" begin
-                    filepath = joinpath(dirpath, f)
-                    @time begin
-                        println("  Including $(filepath)")
-                        include(filepath)
-                    end
-                end
+
+    timings = Tuple{String,Float64}[]
+    @time for (d, f) in _selected
+        filepath = joinpath(@__DIR__, d, f)
+        key = test_file_key(d, f)
+        @testset "$f" begin
+            t = @elapsed begin
+                println("  Including $(filepath)")
+                include(filepath)
+            end
+            println("  [time] $(key): $(round(t; digits=2))s")
+            push!(timings, (key, t))
+        end
+    end
+
+    if _emit
+        open(joinpath(_ciout, "timings-$(_sid).tsv"), "w") do io
+            for (k, t) in timings
+                println(io, k, '\t', round(t; digits=3))
             end
         end
+        println("Emitted $(length(timings)) timing rows -> $(_ciout)/timings-$(_sid).tsv")
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,14 +7,30 @@ using ITensorModels, Test
 # Every test file is `include`d into `Main`, so in a FULL run `Main` ends up holding the
 # UNION of every file's `using` lines — and the suite silently came to depend on that.
 # Concretely: 33 files call `site_type(...)` or construct `SSD()`, but only THREE ever
-# import `site_type`, and NOT ONE imports `SSD` (it is a `LatticeCore` export). The other
-# 30 worked purely because some alphabetically-earlier file had already pulled the name
-# into `Main`.
+# import `site_type` and NOT ONE imports `SSD`. The other 30 worked purely because some
+# alphabetically-earlier file had already pulled the name into `Main`.
 #
 # Under sharding a file can be the ONLY file its job runs, so that leakage evaporates and
-# the shard dies with `UndefVarError: SSD not defined in Main`. Hoist the shared namespace
-# here so every shard sees exactly what a full run sees. This is strictly MORE binding than
-# before (it can only add names, never remove them), so it cannot change any assertion.
+# the shard dies with `UndefVarError`. Hoist the shared namespace here so every shard sees
+# exactly what a full run sees. This is strictly MORE binding than before (it can only add
+# names, never remove them), so it cannot change any assertion.
+#
+# ── The name clash the hoist must disarm ─────────────────────────────
+#
+# `ITensorModels` and `LatticeCore` (hence its re-exporters `Lattice2D` / `QuasiCrystal`)
+# BOTH export three names — `SSD`, `site_type`, `bond_weight` — bound to DIFFERENT objects
+# (`ITensorModels.SSD` is an `AbstractModulation`; `LatticeCore.SSD` is an
+# `AbstractBoundaryModifier`). Two bare `using`s that each export the same name make that
+# name AMBIGUOUS in `Main`: it is not imported at all, and the first use throws
+# `UndefVarError: SSD not defined in Main`.
+#
+# In the old full run this stayed hidden by pure luck of ordering: an alphabetically early
+# file used `SSD` (resolving `Main.SSD` → `ITensorModels.SSD`) BEFORE any file ran a bare
+# `using LatticeCore`, so the later `using` could no longer clobber it. Hoisting the
+# `using`s to the top removes that accident — so the resolution must be made EXPLICIT.
+# `using ITensorModels: …` is an explicit binding and takes precedence over the implicit
+# ambiguity, which is exactly the meaning every test file relies on (every `SSD()` in the
+# suite is a modulation; every `bond_weight`/`site_weight` call is `ITensorModels.`-qualified).
 using Random
 using LinearAlgebra
 using Statistics
@@ -23,7 +39,8 @@ using ITensorMPS
 using LatticeCore
 using Lattice2D
 using QuasiCrystal
-using ITensorModels: site_type, bond_term, build_opsum, local_ham_terms
+using ITensorModels:
+    SSD, site_type, site_weight, bond_weight, bond_term, build_opsum, local_ham_terms
 
 # Canonical universe + completeness guard — the single source of truth, shared
 # VERBATIM with the shard planner (test/ci/plan_shards.jl).

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,29 @@ ENV["GKSwstype"] = "100"
 
 using ITensorModels, Test
 
+# ── Shared namespace (load-order coupling; see below) ────────────────
+#
+# Every test file is `include`d into `Main`, so in a FULL run `Main` ends up holding the
+# UNION of every file's `using` lines — and the suite silently came to depend on that.
+# Concretely: 33 files call `site_type(...)` or construct `SSD()`, but only THREE ever
+# import `site_type`, and NOT ONE imports `SSD` (it is a `LatticeCore` export). The other
+# 30 worked purely because some alphabetically-earlier file had already pulled the name
+# into `Main`.
+#
+# Under sharding a file can be the ONLY file its job runs, so that leakage evaporates and
+# the shard dies with `UndefVarError: SSD not defined in Main`. Hoist the shared namespace
+# here so every shard sees exactly what a full run sees. This is strictly MORE binding than
+# before (it can only add names, never remove them), so it cannot change any assertion.
+using Random
+using LinearAlgebra
+using Statistics
+using ITensors
+using ITensorMPS
+using LatticeCore
+using Lattice2D
+using QuasiCrystal
+using ITensorModels: site_type, bond_term, build_opsum, local_ham_terms
+
 # Canonical universe + completeness guard — the single source of truth, shared
 # VERBATIM with the shard planner (test/ci/plan_shards.jl).
 include(joinpath(@__DIR__, "ci", "universe.jl"))


### PR DESCRIPTION
Ports the QAtlas / ThermalMPS sharded-test CI to ITensorModels. The 43-file suite ran as one serial job; it now fans out to 8 parallel shards.

## What lands

- **`test/ci/universe.jl`** — the canonical test-file universe, the single source of truth for *what* the suite is. Pure stdlib (never `using ITensorModels`), so the planner does not precompile the ITensors stack just to decide how to split. Carries the **completeness guard**: any on-disk directory holding `test_*.jl` that is not enumerated in `ALL_DIRS` is a hard error — a new test dir can never be added and silently run zero tests. `ALL_DIRS = ["base/"]` = this repo's real layout.
- **`test/ci/plan_shards.jl`** — emits the `matrix: include:` JSON. Timings only decide *how* to split: LPT bin-packing against the `ci-timings` orphan branch when present, deterministic round-robin otherwise. Unknown files get a pessimistic P90 estimate. The plan always has `min(N, #files)` shards.
- **`test/runtests.jl`** — `FILES > SHARD > ALL` selection (`ITENSORMODELS_TEST_FILES` / `ITENSORMODELS_TEST_SHARD`), plus per-file wall-clock emission that feeds the next run's planner. **Backward compatible:** with no env vars set, a bare `Pkg.test()` runs all 43 files in the same order as today.
- **`.github/workflows/CI.yml`** — `plan` → 8 `test` shards → aggregated `coverage` → `record-timings` (push:main only) → `all-tests` gate.

## Public-repo runner deltas vs the private reference

ITensorModels is public, so the rosina self-hosted pool is off-limits (a fork PR would otherwise execute arbitrary code on our box). Hence:

- `runs-on: ubuntu-latest` for **every** job, `julia-actions/setup-julia` instead of the juliaup locate step.
- No `gh auth token` git-URL rewrite (rosina-only escape hatch).
- **`julia-actions/cache` with `include-matrix: 'false'`** — a hosted runner has no persistent depot, so without a cache every shard recompiles the whole ITensors stack. The default `include-matrix: true` serialises the entire matrix context (including the multi-KB `files` list) into the cache key, blowing the 512-char limit so *every* restore **and** save fails with "Key Validation Error". `matrix.sid` is already in `cache-name`. (Same trap QAtlas documented.)

## Deviation to flag

ITensorModels has **no Aqua** suite (Aqua is not a test dep), so unlike ThermalMPS/QAtlas nothing here runs it. The planner still emits the `aqua` flag on the lightest shard for parity; `runtests.jl` ignores it, so wiring Aqua in later is a `runtests.jl`-only change. Adding `Aqua.test_all` now would change the default meaning of the suite and could not be validated without running it — left as a follow-up.

## Verification

`julia --startup-file=no test/ci/plan_shards.jl 8 /nonexistent.tsv` → valid JSON, **8 shards** (= `min(8, 43)`), union of shard file lists **== the complete 43-file universe**, no duplicates. Round-robin split: 6/6/6/5/5/5/5/5. `JuliaFormatter` reports the tree already formatted.

The Julia test suite itself was not run locally — CI validates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)