### PR TITLE
fix(ci): PublishRelease uses BOT_PAT for gh pr list

### DIFF
--- a/.github/workflows/PublishRelease.yml
+++ b/.github/workflows/PublishRelease.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build release notes
         id: notes
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
         run: |
           mkdir -p /tmp/release
           python3 .github/scripts/build_release_notes.py \
@@ -57,7 +57,7 @@ jobs:
 
       - name: Create or update release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ steps.tag.outputs.tag }}"
           if gh release view "$TAG" >/dev/null 2>&1; then


### PR DESCRIPTION
Same fix as ParameterizedITensor.jl / the 13 directly-committed repos: the release-notes step's `gh pr list --search` fails with the Actions GITHUB_TOKEN, so use BOT_PAT. Workflow-only, NO version bump (so no registration is triggered on merge).