### PR TITLE
feat(ci): ManifestSnapshot caller (pin release deps)

### DIFF
--- a/.github/workflows/ManifestSnapshot.yml
+++ b/.github/workflows/ManifestSnapshot.yml
@@ -1,0 +1,11 @@
+name: Manifest snapshot
+on:
+  push:
+    branches: [main]
+    paths: [Project.toml]
+  workflow_dispatch:
+jobs:
+  snapshot:
+    permissions:
+      contents: write
+    uses: lab-sotashimozono/.github/.github/workflows/manifest-snapshot.yml@main


### PR DESCRIPTION
Adds the manifests-branch snapshot on version bump. Workflow-only.